### PR TITLE
Add support for `--create-namespace` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Add the following snippet to the script section of your `bitbucket-pipelines.yml
 | CHART (*)                 | Path or name of the chart which should be deployed |
 | RELEASE_NAME              | Name of the helm release |
 | NAMESPACE                 | Target Kubernetes namespace of the deployment. Default: `kube-public`. |
+| CREATE_NAMESPACE          | Create the release namespace if not present |
 | SET                       | List of values which should be used as --set argument for Helm |
 | VALUES                    | Local values YAML files which should be passed to Helm (--values) |
 | DEBUG                     | Debug. Default: `false`. |

--- a/pipe/helm/client.py
+++ b/pipe/helm/client.py
@@ -23,6 +23,7 @@ class HelmClient:
 
   chart = None
   namespace = 'kube-public'
+  create_namespace = False
   release = None
   set = []
   _values = []
@@ -76,6 +77,9 @@ class HelmClient:
 
     if self.wait:
       command.append('--wait')
+
+    if self.create_namespace:
+      command.append('--create-namespace')
 
     return self._run(command)
 

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -45,6 +45,7 @@ class HelmPipe(Pipe):
     chart = self.get_variable('CHART')
     release_name = self.get_variable('RELEASE_NAME')
     namespace = self.get_variable('NAMESPACE')
+    create_namespace = self.get_variable('CREATE_NAMESPACE')
     set = self.get_variable('SET')
     values = self.get_variable('VALUES')
     wait = self.get_variable('WAIT')
@@ -90,6 +91,7 @@ class HelmPipe(Pipe):
     try:
       helm_client = HelmClient(chart)
       helm_client.namespace = namespace
+      helm_client.create_namespace = create_namespace
       helm_client.release = release_name
       helm_client.set = set
       helm_client.values = values

--- a/pipe/schema.py
+++ b/pipe/schema.py
@@ -31,6 +31,7 @@ def get_schema():
     'CHART': {'type': 'string', 'required': True},
     'RELEASE_NAME': {'type': 'string', 'required': False, 'nullable': True},
     'NAMESPACE': {'type': 'string', 'required': False, 'default': 'kube-public'},
+    'CREATE_NAMESPACE': {'type': 'boolean', 'required': False, 'default': False},
     'SET': {'type': 'list', 'required': False, 'default': []},
     'VALUES': {'type': 'list', 'required': False, 'default': []},
     'WAIT': {'type': 'boolean', 'required': False, 'default': False},

--- a/test/acceptance/test_pipe.py
+++ b/test/acceptance/test_pipe.py
@@ -65,6 +65,7 @@ def test_success(capsys):
     '-e', 'CHART=/tmp/chart/test',
     '-e', 'RELEASE_NAME=test',
     '-e', 'NAMESPACE=test',
+    '-e', 'CREATE_NAMESPACE=true',
     '-e', 'SET_COUNT=1',
     '-e', 'SET_0="replicaCount=2"',
     '-e', 'VALUES_COUNT=1',
@@ -88,6 +89,7 @@ def test_success(capsys):
 
   assert 'helm upgrade test /tmp/chart/test --install' in result.stdout
   assert '--namespace test' in result.stdout
+  assert '--create-namespace' in result.stdout
   assert '--set "replicaCount=2"' in result.stdout
   assert '--set "bitbucket.bitbucket_build_number=1234"' in result.stdout
   assert '--set "bitbucket.bitbucket_repo_slug=test"' in result.stdout


### PR DESCRIPTION
Greetings!!

Thank you for this useful tool.

Similar to https://github.com/yves-vogl/aws-eks-helm-deploy/pull/2, we were wondering if you have any thoughts about adding support for the new `--create-namespace` functionality added in Helm 3:

- https://helm.sh/docs/faq/changes_since_helm2/#automatically-creating-namespaces
- https://github.com/helm/helm/pull/7648

We found this could be helpful when deploying to multiple environments for the first time.
Here's a PR modeled after the previous one, but feel free to give it a try or comment or update or reject as you wish.

Thanks!