### PR TITLE
docs: profile-visibility pass — badges, version matrix, v2 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,134 @@
 # Bitbucket Pipelines Pipe: AWS EKS Helm Deploy
 
-Deploy [Helm](https://helm.sh) charts to [AWS Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html).
+[![License](https://img.shields.io/github/license/yves-vogl/aws-eks-helm-deploy)](LICENSE.txt)
+[![GitHub release](https://img.shields.io/github/v/release/yves-vogl/aws-eks-helm-deploy?label=release&sort=semver)](https://github.com/yves-vogl/aws-eks-helm-deploy/releases)
+[![Docker Image Version](https://img.shields.io/docker/v/yvogl/aws-eks-helm-deploy?sort=semver&label=docker%20image)](https://hub.docker.com/r/yvogl/aws-eks-helm-deploy)
+[![Docker Pulls](https://img.shields.io/docker/pulls/yvogl/aws-eks-helm-deploy)](https://hub.docker.com/r/yvogl/aws-eks-helm-deploy)
+[![GitHub stars](https://img.shields.io/github/stars/yves-vogl/aws-eks-helm-deploy?style=flat)](https://github.com/yves-vogl/aws-eks-helm-deploy/stargazers)
+[![Open issues](https://img.shields.io/github/issues/yves-vogl/aws-eks-helm-deploy)](https://github.com/yves-vogl/aws-eks-helm-deploy/issues)
 
+Deploy [Helm](https://helm.sh) charts to [AWS Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html) from [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines) — a thin, opinionated wrapper around `helm upgrade --install` that handles EKS authentication for you.
 
 ![Logo](logo.png)
 
-![GitHub Created At](https://img.shields.io/github/created-at/yves-vogl/aws-eks-helm-deploy)
-![Docker Pulls](https://img.shields.io/docker/pulls/yvogl/aws-eks-helm-deploy)
-![Docker Image Version](https://img.shields.io/docker/v/yvogl/aws-eks-helm-deploy)
+---
 
+## What this pipe does
 
-## YAML Definition
+- Resolves AWS credentials (static keys, optionally with `ROLE_ARN` assumption via STS).
+- Builds a kubeconfig for your EKS cluster on the fly — **no `kubectl` install required in your pipeline image**.
+- Runs `helm upgrade --install` against the cluster with the variables you provide.
+- Injects Bitbucket build metadata (build number, commit, tag, …) as Helm values so your charts can reference them.
 
-Add the following snippet to the script section of your `bitbucket-pipelines.yml` file:
+This pipe is purpose-built for **Bitbucket Pipelines**. For GitHub Actions, use upstream actions such as [`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) combined with a Helm action.
+
+> **Status:** v1.3.0 is the current stable release. **v2.0 is in active development** — see [Milestone `v2.0.0`](https://github.com/yves-vogl/aws-eks-helm-deploy/milestones) for tracked work (OIDC/IRSA, OCI chart support, history pruning, dry-run, signed images, ADRs, 100% test coverage).
+
+---
+
+## Quick start
+
+Drop the following step into your `bitbucket-pipelines.yml`:
 
 ```yaml
-- pipe: docker://yvogl/aws-eks-helm-deploy:1.3.0
-  variables:
-    AWS_ACCESS_KEY_ID: "<string>"
-    AWS_SECRET_ACCESS_KEY: "<string>"
-    CLUSTER_NAME: "<string>"
-    CHART: "<string>"
+image: atlassian/default-image:4
+
+pipelines:
+  branches:
+    main:
+      - step:
+          name: Deploy to EKS
+          deployment: production
+          script:
+            - pipe: docker://yvogl/aws-eks-helm-deploy:1.3.0
+              variables:
+                AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
+                AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+                AWS_REGION: eu-central-1
+                CLUSTER_NAME: my-eks-cluster
+                CHART: ./charts/my-app
+                RELEASE_NAME: my-app
+                NAMESPACE: production
+                CREATE_NAMESPACE: "true"
+                WAIT: "true"
+                TIMEOUT: "10m"
 ```
+
+Pin the pipe to a specific tag (e.g. `:1.3.0`). Consumers that pin to `:latest` get whatever was last pushed — avoid that in production.
+
+---
 
 ## Variables
 
-| Variable                  | Usage                                                                  |
-| ------------------------- | ---------------------------------------------------------------------- |
-| AWS_REGION                | AWS Region. Default: `eu-central-1`. |
-| AWS_ACCESS_KEY_ID (*)     | AWS Access Key ID |
-| AWS_SECRET_ACCESS_KEY (*) | AWS Secret Access Key |
-| ROLE_ARN                  | AWS IAM Role to assume when access EKS |
-| SESSION_NAME              | AWS STS Session name |
-| CLUSTER_NAME (*)          | Name of the AWS EKS cluster |
-| CHART (*)                 | Path or name of the chart which should be deployed |
-| RELEASE_NAME              | Name of the helm release |
-| NAMESPACE                 | Target Kubernetes namespace of the deployment. Default: `kube-public`. |
-| CREATE_NAMESPACE          | Create the release namespace if not present |
-| SET                       | List of values which should be used as --set argument for Helm |
-| VALUES                    | Local values YAML files which should be passed to Helm (--values) |
-| TIMEOUT                   | Timeout. Default: `5m`. |
-| WAIT                      | Wait until application is ready. Default: `false`. |
-| DEBUG                     | Debug. Default: `false`. |
+| Variable                  | Required | Default          | Description                                                                 |
+| ------------------------- | :------: | ---------------- | --------------------------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`       |    ✓     | —                | AWS access key ID.                                                          |
+| `AWS_SECRET_ACCESS_KEY`   |    ✓     | —                | AWS secret access key.                                                      |
+| `CLUSTER_NAME`            |    ✓     | —                | Name of the target EKS cluster.                                             |
+| `CHART`                   |    ✓     | —                | Path or name of the Helm chart to deploy.                                   |
+| `AWS_REGION`              |          | `eu-central-1`   | AWS region the cluster lives in.                                            |
+| `ROLE_ARN`                |          | —                | IAM role to assume via STS before talking to EKS.                           |
+| `SESSION_NAME`            |          | —                | STS session name when assuming `ROLE_ARN`.                                  |
+| `RELEASE_NAME`            |          | `$CHART`         | Name of the Helm release.                                                   |
+| `NAMESPACE`               |          | `default`        | Target Kubernetes namespace.                                                |
+| `CREATE_NAMESPACE`        |          | `false`          | Pass `--create-namespace` to Helm.                                          |
+| `SET`                     |          | `[]`             | List of values forwarded to Helm as `--set` arguments.                      |
+| `VALUES`                  |          | `[]`             | Local values YAML files forwarded to Helm as `--values` arguments.          |
+| `WAIT`                    |          | `false`          | Wait for resources to become ready (`helm --wait`).                         |
+| `TIMEOUT`                 |          | `5m`             | Helm timeout, Go duration syntax (e.g. `30s`, `5m`, `1h`).                  |
+| `DEBUG`                   |          | `false`          | Verbose logging.                                                            |
 
-_(*) = required variable._
+The pipe also injects the following Bitbucket build metadata as `--set` values, so your chart templates can reference them: `bitbucket.bitbucket_build_number`, `bitbucket.bitbucket_repo_slug`, `bitbucket.bitbucket_commit`, `bitbucket.bitbucket_tag`, `bitbucket.bitbucket_step_triggerer_uuid`.
 
-## Prerequisites
+> Charts with strict `values.schema.json` validation may reject these fields. An opt-out flag is tracked for v2.0 in [#16](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/16).
+
+---
+
+## Authentication
+
+Today the pipe authenticates using **static AWS access keys**, optionally combined with `ROLE_ARN` assumption via STS. Store keys as [secured repository or deployment variables](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/) — never commit them.
+
+**Native OIDC / IRSA (Bitbucket OIDC → STS `AssumeRoleWithWebIdentity`)** support is on the v2.0 roadmap — see [#3](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/3). OIDC eliminates long-lived AWS keys in your pipeline and is the recommended pattern for production deployments going forward.
+
+---
+
+## Version matrix
+
+The `yvogl/aws-eks-helm-deploy:1.3.0` image bundles:
+
+| Component                      | Version           | Notes                                                                  |
+| ------------------------------ | ----------------- | ---------------------------------------------------------------------- |
+| Base image                     | `python:3-alpine` | Latest 3.x at image build time.                                        |
+| Helm                           | `3.15.1`          | Copied from `alpine/helm:3.15.1`. Compatible with EKS Kubernetes versions supported by Helm 3.15 — see the [Helm version skew policy](https://helm.sh/docs/topics/version_skew/). |
+| `kubectl`                      | not bundled       | The pipe generates a kubeconfig and lets Helm talk to the EKS API directly. |
+| `awscli`                       | `~=1.32`          | Used for EKS token generation (`TokenGenerator`).                      |
+| `bitbucket-pipes-toolkit`      | `~=4.4`           | Pipe scaffolding, schema validation, logging.                          |
+| Jinja2                         | `~=3.1`           | Kubeconfig templating.                                                 |
+
+Tooling versions are advanced in lockstep with each release. See [`CHANGELOG.md`](CHANGELOG.md) for the per-release upgrade history.
+
+---
 
 ## Examples
 
-Basic example:
+### Basic
 
 ```yaml
 script:
   - pipe: docker://yvogl/aws-eks-helm-deploy:1.3.0
     variables:
-      NAME: "foobar"
+      AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+      CLUSTER_NAME: my-cluster
+      CHART: ./charts/my-app
 ```
 
-Advanced example which uses AWS SecretsManager and different AWS IAM Roles
+### Pull secrets from AWS Secrets Manager, then deploy with a different IAM role
 
 ```yaml
-
 script:
   - step:
-      name: Deploy
+      name: Fetch secrets
       image: amazon/aws-cli
       deployment: Development
       caches:
@@ -95,15 +159,35 @@ script:
       VALUES: [
         secrets.yaml
       ]
-
 ```
 
-## Support
-If you’d like help with this pipe, or you have an issue or feature request, let me know.
-The pipe is maintained by yves.vogl@adesso.de
+---
 
-If you’re reporting an issue, please include:
+## Roadmap
 
-- the version of the pipe
-- relevant logs and error messages
-- steps to reproduce
+The **[v2.0.0 milestone](https://github.com/yves-vogl/aws-eks-helm-deploy/milestones)** tracks the planned modernization:
+
+- Native AWS OIDC / IRSA authentication
+- Helm OCI registry and `repo://` chart support
+- `helm --history-max` integration for release history pruning ([#17](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/17))
+- Opt-out for injected Bitbucket metadata ([#16](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/16))
+- Multi-architecture image (linux/amd64 + linux/arm64)
+- Cosign-signed images + SBOM
+- 100% test coverage (unit + integration)
+- GitHub Actions release pipeline
+
+---
+
+## Support and contributing
+
+- **Questions or bug reports** → open a [GitHub issue](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/new/choose). Please include the pipe version, your `bitbucket-pipelines.yml` snippet, and the relevant log output.
+- **Security reports** → please report privately rather than via a public issue; see `SECURITY.md` once available (tracked for v2.0).
+- **Pull requests welcome** — contribution guidelines (`CONTRIBUTING.md`) and PR template are tracked for v2.0.
+
+Maintained by [Yves Vogl](https://github.com/yves-vogl).
+
+---
+
+## License
+
+[Apache License 2.0](LICENSE.txt).


### PR DESCRIPTION
## Summary

Profile-visibility polish for the v1.3.0 line, alongside triage of the open issues, so the project no longer reads as unmaintained while the **v2.0** modernization is under construction.

This PR is documentation-only. The Docker image is **not** rebuilt or re-tagged — pinned consumers (`docker://yvogl/aws-eks-helm-deploy:1.3.0`) are not affected.

## What changed in the README

- **Badge row at the top** — License, GitHub release, Docker image version, Docker pulls, stars, open issues. Dropped the low-signal `Created-At` badge.
- **Market positioning** — explicit "Bitbucket Pipelines only" framing, pointer to GitHub Actions alternatives.
- **Status callout** — links to [milestone v2.0.0](https://github.com/yves-vogl/aws-eks-helm-deploy/milestones) so the project visibly has a forward plan.
- **Quick-start block** — full `bitbucket-pipelines.yml` snippet with `image`, branch trigger, deployment env, required + recommended variables.
- **Variables table** — required column, defaults column, documentation of the injected `bitbucket.*` metadata fields, link to #16 for the planned opt-out.
- **Authentication section** — explicit "today: static keys + `ROLE_ARN`" framing, points at planned OIDC/IRSA (#3).
- **Version matrix** — Helm 3.15.1, awscli ~=1.32, Jinja2 ~=3.1, bitbucket-pipes-toolkit ~=4.4, base image; link to Helm version skew policy for EKS compatibility.
- **Roadmap section** — enumerates v2.0 work (OIDC, OCI/repo chart support, history pruning, opt-out for injected metadata, multi-arch, Cosign, SBOM, 100% test coverage, GitHub Actions release).
- **Removed** the broken empty `## Prerequisites` header.
- **Removed** the hardcoded `yves.vogl@adesso.de` support email — replaced with a GitHub issues pointer and references to upcoming `CONTRIBUTING.md` / `SECURITY.md`.

## Related issues & repo cleanup (done alongside this PR, not part of the diff)

- Triage on the 2 open issues:
  - **#17** (history pruning) — accepted into milestone v2.0.0, labels `enhancement, area/helm, good first issue, priority/p2`, comment confirming `--history-max` as the right primitive.
  - **#16** (opt-out for injected Bitbucket metadata) — accepted into milestone v2.0.0, labels `enhancement, area/helm, breaking-change, priority/p1`, comment naming the planned default flip in v2 and the workaround in v1.
- **Milestone `v2.0.0`** created with the modernization scope.
- **Label taxonomy** extended: `area/{auth,helm,ci,release,docs,image,security}`, `type/refactor`, `breaking-change`, `priority/{p0,p1,p2}`.

## Test plan

- [ ] Render README on GitHub and check that all six badges resolve.
- [ ] Confirm milestone link from the README opens [milestone v2.0.0](https://github.com/yves-vogl/aws-eks-helm-deploy/milestones).
- [ ] Confirm `#3`, `#16`, `#17` references render as cross-links.
- [ ] Spot-check that the Quick-start block is copy-pasteable into a clean `bitbucket-pipelines.yml`.
- [ ] No code changes — no CI run required beyond docs validation.