### PR TITLE
chore(planning): initialize GSD planning for v2.0 modernization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .venv
+.DS_Store

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,159 @@
+# aws-eks-helm-deploy — v2.0 Modernization
+
+## What This Is
+
+`aws-eks-helm-deploy` is a Bitbucket Pipelines Pipe that deploys [Helm](https://helm.sh) charts to AWS Elastic Kubernetes Service (EKS) from a Bitbucket Pipeline. It wraps `helm upgrade --install` with on-the-fly EKS authentication (no `kubectl` install required in the consumer's pipeline image) and injects Bitbucket build metadata as Helm values. v1.3.0 is the current stable release on Docker Hub (`yvogl/aws-eks-helm-deploy`). This project tracks the **v2.0 modernization**: a state-of-the-art rewrite that moves development primary to GitHub, ships 100% test coverage, native AWS OIDC/IRSA, OCI/Helm-repo chart support, multi-arch signed images, and a fully automated GitHub Actions release pipeline.
+
+## Core Value
+
+**A maintainer can ship a Bitbucket Pipelines deployment to AWS EKS from a clean repository in under five minutes — without committing static AWS credentials and without surprises at upgrade time.** Every other concern (multi-arch, SBOM, OCI charts, rollback) is in service of that one promise. If that experience breaks, v2 has failed regardless of how clean the code is.
+
+## Requirements
+
+### Validated
+
+<!-- Inherited from existing v1.x code — already shipped, in production use by 9+ public consumers. -->
+
+- ✓ Deploys Helm charts to AWS EKS via `helm upgrade --install` — v1.x
+- ✓ Authenticates to EKS using static AWS keys + optional `ROLE_ARN` STS assumption — v1.x
+- ✓ Generates kubeconfig on the fly from `eks describe-cluster` + STS token — v1.x
+- ✓ Supports `--namespace`, `--create-namespace`, `--set`, `--values`, `--wait`, `--timeout` (Go duration) — v1.x
+- ✓ Injects Bitbucket build metadata (`bitbucket.bitbucket_build_number`, etc.) as Helm values — v1.x
+- ✓ Apache-2.0 licensed, semversioner-managed CHANGELOG — v1.x
+- ✓ Distributed as Docker Hub image `yvogl/aws-eks-helm-deploy` — v1.x
+
+### Active
+
+<!-- v2.0 scope. Hypotheses until shipped. -->
+
+**Modernization baseline (functional parity + cleanup)**
+
+- [ ] All Python source migrated to `src/` layout with `pyproject.toml`; `requirements.txt` removed
+- [ ] Toolchain: `uv` for env/dependency management, `ruff` for lint+format, `mypy --strict` for typing, `pytest` for tests
+- [ ] 100% unit-test line+branch coverage of `pipe/*` modules (mocked AWS, mocked Helm)
+- [ ] Integration tests against a real local Kubernetes (`kind` or `k3d`) running real Helm
+- [ ] Acceptance tests (Docker image invocation) retained and migrated to GitHub Actions
+- [ ] `helm` invocation hardened: replace bare `subprocess.run` + `BaseException` with typed wrapper
+- [ ] Replace `BaseException` subclasses with `Exception` subclasses; introduce a clear exception hierarchy
+- [ ] Replace fragile `awscli.customizations.eks.get_token` internal import with `boto3`-only EKS token generation
+- [ ] Drop the heavyweight `awscli` dependency in favor of `boto3` (already pulled in transitively)
+- [ ] Fix `NAMESPACE` default inconsistency (README says `kube-public`, `pipe.yml` says `default`) → choose `default`, document in CHANGELOG
+- [ ] OCI image labels (OCI annotations: source, revision, licenses, description)
+- [ ] Multi-arch image build: `linux/amd64` + `linux/arm64`
+
+**New features (v2.0 scope, on top of baseline)**
+
+- [ ] **AWS OIDC / IRSA** as first-class authentication path — Bitbucket OIDC token → STS `AssumeRoleWithWebIdentity` → EKS token. Static keys remain as a fallback. (Closes Bitbucket Pipelines OIDC support gap — see #3.)
+- [ ] **Helm repository and OCI chart support** — `CHART` accepts `oci://…`, `repo://…/chart`, plus `CHART_VERSION` and `REPO_URL` variables. (Closes #7.)
+- [ ] **Dry-run / diff preview** — `DRY_RUN=true` runs `helm diff upgrade` (requires bundled `helm-diff` plugin) and surfaces the diff in pipeline logs for PR-preview workflows. No mutation against the cluster.
+- [ ] **Rollback subcommand** — `ACTION=rollback` with `REVISION=<n>` triggers `helm rollback` instead of `upgrade --install`.
+- [ ] **Release history pruning** — `HISTORY_MAX` variable wraps `helm --history-max`. (Closes #17.)
+- [ ] **Opt-in Bitbucket metadata injection** — `INJECT_BITBUCKET_METADATA` variable, default `false` in v2 (was unconditional in v1). Breaking change. (Closes #16.)
+
+**Distribution and supply-chain modernization**
+
+- [ ] GitHub Actions release pipeline as the new source-of-truth (Bitbucket Pipelines becomes a thin mirror that only re-publishes the Pipe Marketplace listing)
+- [ ] Conventional-Commits → automatic SemVer via `release-please` (replaces `semversioner` + `.changes/`)
+- [ ] Docker images pushed to **both** Docker Hub (`yvogl/aws-eks-helm-deploy`) and GitHub Container Registry (`ghcr.io/yves-vogl/aws-eks-helm-deploy`)
+- [ ] Image signed with **Cosign** (keyless, GitHub Actions OIDC); SBOM published as image attestation (Syft + SPDX or CycloneDX)
+- [ ] **Trivy / Grype** vulnerability scan as a CI gate on every build
+- [ ] **pip-audit** dependency scan as a CI gate
+- [ ] **Dependabot** for Python + Docker + GitHub Actions dependencies; auto-merge enabled when CI green (incl. major bumps, per project policy)
+- [ ] Branch protection on `main` (signed commits, required reviews, required status checks)
+
+**Documentation and community**
+
+- [ ] **ADRs** (`docs/adr/`) for every architectural decision (forge primacy, OIDC over static keys, GitHub Actions over Bitbucket Pipelines for release, Cosign over GPG image signing, etc.)
+- [ ] `CONTRIBUTING.md` with dev-loop instructions (`uv sync`, `ruff check`, `pytest`, `kind` setup)
+- [ ] `SECURITY.md` with private-disclosure flow and supported-version policy
+- [ ] `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
+- [ ] `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml` + `.github/PULL_REQUEST_TEMPLATE.md`
+- [ ] `examples/` directory with end-to-end `bitbucket-pipelines.yml` snippets per common scenario (basic, multi-env deployments, OIDC, OCI chart)
+- [ ] Versioned documentation: `docs/v1/` retains v1.x usage, `docs/v2/` for v2 (`mkdocs-material` or similar, hosted via GitHub Pages — TBD by research)
+- [ ] **Migration guide** v1 → v2 documenting every breaking change
+
+### Out of Scope
+
+<!-- Explicit boundaries with reasoning. Do not re-add without explicit revisit. -->
+
+- **GitHub Actions as a first-party invocation surface** — This is a Bitbucket Pipelines Pipe. GitHub Actions consumers are pointed at `aws-actions/configure-aws-credentials` + a Helm action. Reason: the Bitbucket Pipes Toolkit shapes the entire env-var-driven invocation contract; turning this into an Action would be a different project.
+- **Multi-cluster atomic deploy in one Pipe call** — Composability via multiple pipe steps in `bitbucket-pipelines.yml` is sufficient. Reason: complexity blast radius too high for v2.0 timeline.
+- **GUI / web frontend** — The product is a CI Pipe. Reason: not applicable.
+- **Self-hosting helm chart of this pipe** — out of scope; this is a CLI-style container, not a service.
+- **Kubernetes-in-Kubernetes nested cluster deployment** — not in EKS focus area. Reason: scope creep.
+- **GPG signing of Docker images** — replaced by Cosign keyless signing. Reason: GPG image signing is dead-tech for OCI distribution.
+- **`semversioner`-managed releases** — replaced by `release-please` driven by Conventional Commits. Reason: tighter GitHub-Actions integration and Conventional-Commit alignment.
+
+## Context
+
+**Existing user base:**
+- Public GitHub repo: 9 stars, 15 forks, **2 open issues** (now triaged to v2.0.0 milestone), 10 closed PRs.
+- Docker Hub: `yvogl/aws-eks-helm-deploy` with measurable pull activity (badge in README).
+- Real consumers exist and pin to `:1.3.0` — **v2.0 is a clean break, marked clearly, with v1.x supported via existing image tags** (no rebuild).
+
+**Active backlog ingested into v2.0 (GitHub milestone v2.0.0):**
+- [#17 — `--history-max` support](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/17) — community-suggested, simple integration
+- [#16 — opt-out for injected Bitbucket metadata](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/16) — chart-schema-validation conflict; in v2 the default flips to opt-in (breaking change)
+- [#3 — OIDC support](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/3) (closed but never implemented) — re-prioritized as a v2.0 baseline feature
+- [#7 — chart repo / version support](https://github.com/yves-vogl/aws-eks-helm-deploy/issues/7) (closed but never implemented) — re-prioritized
+
+**Tech baseline of v1.3.0 (the modernization starting point):**
+- Python with `requirements.txt`: `awscli ~=1.32`, `bitbucket-pipes-toolkit ~=4.4`, `docker ~=7.1`, `Jinja2 ~=3.1`, `MarkupSafe ~=2.1`
+- Source layout: `pipe/{pipe.py, schema.py, test.py, eks/, helm/, templates/}` — flat, no `src/`
+- Helm `3.15.1` from `alpine/helm` base; image base `python:3-alpine`
+- Tests: **acceptance only** (`test/acceptance/test_pipe.py` builds the image and runs `docker run` with mocked Helm via `/opt/pipe/test.py`); **no unit tests, no `pytest-cov`, no lint, no type check**
+- CI: Bitbucket Pipelines runs acceptance tests on every push, then on main pushes via `bitbucketpipelines/bitbucket-pipe-release:5.6.1` to Docker Hub
+- Releases: `semversioner add-change --type {major|minor|patch} --description "..."` writes `.changes/next-release/*.json`; on main merge, the Bitbucket release pipe bumps version, regenerates `CHANGELOG.md`, updates `pipe.yml` + README version, tags, pushes to Docker Hub
+- Code style: 2-space indents (non-PEP8), no type hints, no formatter config, `BaseException` subclasses
+
+**Maintainer constraints (project-specific carry-over from user-global standards):**
+- All technical artefacts in English (code, commits, PRs, ADRs, READMEs, docstrings)
+- All commits and tags must be GPG-signed (`commit.gpgsign=true`, signing key on file)
+- Conventional Commits everywhere
+- Never commit directly to `main` — all changes via feature branch + PR
+- No AI/Claude attribution in commits, PRs, or any artefact (maintainer is the only listed author)
+- Maximum cost discipline: Sonnet for implementation subagents, Opus reserved for strategy and review
+
+## Constraints
+
+- **Distribution channel**: Bitbucket Pipes Marketplace requires `pipe.yml` + Docker Hub image + Bitbucket-hosted listing repo. Bitbucket-side mirror must remain functional even when GitHub becomes primary.
+- **Backwards compatibility**: v2.0 is a **clean major-version break**. The promise to existing v1.x consumers is "your pinned image keeps working forever" — not "v2 is a drop-in replacement". Every breaking change is explicit in the migration guide.
+- **Auth**: AWS OIDC requires Bitbucket Pipelines to issue the OIDC token (`BITBUCKET_STEP_OIDC_TOKEN`) and the configured AWS IAM role to trust the Bitbucket OIDC provider. The pipe itself only exchanges the token via STS — IAM setup is the consumer's responsibility (documented).
+- **Helm version skew**: The bundled Helm version dictates which Kubernetes minor versions the pipe supports (see Helm version skew policy). v2.0 ships with Helm 3.16+ at minimum; pinning policy is one of the ADRs.
+- **Performance**: cold pipe execution should complete in under 60 seconds for a trivial chart on a small EKS cluster (no regression from v1.3.0). The full `awscli` dependency is the current latency hotspot.
+- **Security**: no long-lived secrets in pipe code or image. OIDC keyless signing requires GitHub Actions to be the release driver (not Bitbucket).
+- **Test infrastructure**: a Bitbucket account is required for end-to-end pipe acceptance tests (must run inside Bitbucket Pipelines to exercise the real `bitbucket-pipes-toolkit` runtime). Unit + Kubernetes-integration tests run on GitHub Actions.
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| GitHub becomes primary forge; Bitbucket reduces to read-only mirror + Pipe-Marketplace publishing | Modern security toolchain (OIDC, Cosign, Dependabot) lives in GitHub Actions; PR/issue community is larger on GitHub | — Pending |
+| v2.0 is a clean break, not backwards-compatible with v1.x | Allows fixing the `NAMESPACE` default bug, flipping `INJECT_BITBUCKET_METADATA` to off, and renaming variables for clarity | — Pending |
+| `release-please` replaces `semversioner` | Tighter Conventional-Commits + GitHub-native release flow; eliminates `.changes/` ceremony | — Pending |
+| Cosign keyless signing replaces unsigned Docker images | OIDC-driven, no key management, OCI-native | — Pending |
+| `boto3`-only for EKS token generation (drop full `awscli`) | Removes ~120 MB and a fragile internal import (`awscli.customizations.eks.get_token`) | — Pending |
+| `uv` for dependency and venv management | Fastest modern Python tooling, lockfile-driven, replaces ad-hoc `pip install -r requirements.txt` | — Pending |
+| Bundle `helm-diff` plugin in the image for dry-run support | Required for the `DRY_RUN` feature; small footprint | — Pending |
+| Documentation site (`mkdocs-material` vs. GitHub Pages from README only) | TBD by research phase | — Pending |
+| Multi-arch image (`linux/amd64` + `linux/arm64`) | Apple Silicon developers can pull the image locally; some EKS Graviton runners; cost negligible with `docker buildx` | — Pending |
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd-transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd-complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+
+---
+*Last updated: 2026-06-16 after initialization*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -153,29 +153,94 @@ Explicit boundaries. Anti-features carry reasoning so re-adding requires explici
 
 ## Traceability
 
-Empty initially. Populated by `gsd-roadmapper` when ROADMAP.md is generated.
+Populated by `gsd-roadmapper` on 2026-06-16 — every v1 REQ mapped to exactly one phase.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| TOOL-01..08 | TBD | Pending |
-| AUTH-01..07 | TBD | Pending |
-| CHART-01..05 | TBD | Pending |
-| PIPE-01..06 | TBD | Pending |
-| HISTORY-01..02 | TBD | Pending |
-| META-01..03 | TBD | Pending |
-| IMAGE-01..06 | TBD | Pending |
-| SEC-01..06 | TBD | Pending |
-| CI-01..07 | TBD | Pending |
-| OBS-01..02 | TBD | Pending |
-| DOC-01..08 | TBD | Pending |
-| CMN-01..04 | TBD | Pending |
-| MIG-01..03 | TBD | Pending |
+| TOOL-01 | Phase 1 | Pending |
+| TOOL-02 | Phase 1 | Pending |
+| TOOL-03 | Phase 1 | Pending |
+| TOOL-04 | Phase 1 | Pending |
+| TOOL-05 | Phase 1 | Pending |
+| TOOL-06 | Phase 1 | Pending |
+| TOOL-07 | Phase 1 | Pending |
+| TOOL-08 | Phase 1 | Pending |
+| AUTH-01 | Phase 2 | Pending |
+| AUTH-02 | Phase 2 | Pending |
+| AUTH-03 | Phase 4 | Pending |
+| AUTH-04 | Phase 4 | Pending |
+| AUTH-05 | Phase 4 | Pending |
+| AUTH-06 | Phase 4 | Pending |
+| AUTH-07 | Phase 2 | Pending |
+| CHART-01 | Phase 3 | Pending |
+| CHART-02 | Phase 4 | Pending |
+| CHART-03 | Phase 4 | Pending |
+| CHART-04 | Phase 4 | Pending |
+| CHART-05 | Phase 3 | Pending |
+| PIPE-01 | Phase 3 | Pending |
+| PIPE-02 | Phase 5 | Pending |
+| PIPE-03 | Phase 5 | Pending |
+| PIPE-04 | Phase 5 | Pending |
+| PIPE-05 | Phase 5 | Pending |
+| PIPE-06 | Phase 3 | Pending |
+| HISTORY-01 | Phase 3 | Pending |
+| HISTORY-02 | Phase 3 | Pending |
+| META-01 | Phase 3 | Pending |
+| META-02 | Phase 5 | Pending |
+| META-03 | Phase 5 | Pending |
+| IMAGE-01 | Phase 1 | Pending |
+| IMAGE-02 | Phase 1 | Pending |
+| IMAGE-03 | Phase 1 | Pending |
+| IMAGE-04 | Phase 6 | Pending |
+| IMAGE-05 | Phase 1 | Pending |
+| IMAGE-06 | Phase 6 | Pending |
+| SEC-01 | Phase 6 | Pending |
+| SEC-02 | Phase 6 | Pending |
+| SEC-03 | Phase 6 | Pending |
+| SEC-04 | Phase 6 | Pending |
+| SEC-05 | Phase 6 | Pending |
+| SEC-06 | Phase 5 | Pending |
+| CI-01 | Phase 6 | Pending |
+| CI-02 | Phase 6 | Pending |
+| CI-03 | Phase 6 | Pending |
+| CI-04 | Phase 6 | Pending |
+| CI-05 | Phase 6 | Pending |
+| CI-06 | Phase 6 | Pending |
+| CI-07 | Phase 6 | Pending |
+| OBS-01 | Phase 1 | Pending |
+| OBS-02 | Phase 1 | Pending |
+| DOC-01 | Phase 7 | Pending |
+| DOC-02 | Phase 7 | Pending |
+| DOC-03 | Phase 7 | Pending |
+| DOC-04 | Phase 7 | Pending |
+| DOC-05 | Phase 7 | Pending |
+| DOC-06 | Phase 7 | Pending |
+| DOC-07 | Phase 7 | Pending |
+| DOC-08 | Phase 7 | Pending |
+| CMN-01 | Phase 6 | Pending |
+| CMN-02 | Phase 6 | Pending |
+| CMN-03 | Phase 6 | Pending |
+| CMN-04 | Phase 6 | Pending |
+| MIG-01 | Phase 6 | Pending |
+| MIG-02 | Phase 5 | Pending |
+| MIG-03 | Phase 7 | Pending |
 
 **Coverage:**
-- v1 requirements: **57** total
-- Mapped to phases: 0 (pending roadmap)
-- Unmapped: 57 ⚠️ (expected — will be 0 after roadmap creation)
+- v1 requirements: **67** total (8 TOOL + 7 AUTH + 5 CHART + 6 PIPE + 2 HISTORY + 3 META + 6 IMAGE + 6 SEC + 7 CI + 2 OBS + 8 DOC + 4 CMN + 3 MIG)
+- Mapped to phases: **67** (100%)
+- Unmapped: **0** ✓
+
+**Distribution per phase:**
+- Phase 1 (Toolchain & Spine): 14 REQs — TOOL-01..08, IMAGE-01, IMAGE-02, IMAGE-03, IMAGE-05, OBS-01, OBS-02
+- Phase 2 (AWS Layer & Auth Foundation): 3 REQs — AUTH-01, AUTH-02, AUTH-07
+- Phase 3 (Helm Core & Upgrade Action): 7 REQs — CHART-01, CHART-05, PIPE-01, PIPE-06, HISTORY-01, HISTORY-02, META-01
+- Phase 4 (OIDC & Chart Source Extensions): 7 REQs — AUTH-03, AUTH-04, AUTH-05, AUTH-06, CHART-02, CHART-03, CHART-04
+- Phase 5 (Log Masking, Diff, Rollback & Metadata Flip): 8 REQs — SEC-06, PIPE-02, PIPE-03, PIPE-04, PIPE-05, META-02, META-03, MIG-02
+- Phase 6 (Release Pipeline & Supply Chain): 19 REQs — IMAGE-04, IMAGE-06, SEC-01..05, CI-01..07, CMN-01..04, MIG-01
+- Phase 7 (Documentation Site & Migration Guide): 9 REQs — DOC-01..08, MIG-03
+
+Sum: 14 + 3 + 7 + 7 + 8 + 19 + 9 = 67 ✓
 
 ---
 *Requirements defined: 2026-06-16*
-*Last updated: 2026-06-16 after initialization*
+*Last updated: 2026-06-16 after roadmap creation (traceability populated)*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,181 @@
+# Requirements: aws-eks-helm-deploy v2.0
+
+**Defined:** 2026-06-16
+**Core Value:** A maintainer can ship a Bitbucket Pipelines deployment to AWS EKS from a clean repository in under five minutes — without committing static AWS credentials and without surprises at upgrade time.
+
+Two consumer-side personas drive the requirements: **(M)** the maintainer of a downstream service who configures the pipe in their `bitbucket-pipelines.yml`, and **(D)** the developer of this Pipe (you) who maintains, tests, releases, and supports it. Most requirements are written from M's perspective; toolchain/CI/release requirements are written from D's.
+
+## v1 Requirements
+
+### Toolchain (TOOL) — developer experience
+
+- [ ] **TOOL-01**: D can install all dev dependencies with `uv sync --all-extras` in under 10 seconds on a warm cache.
+- [ ] **TOOL-02**: Source code lives under `src/aws_eks_helm_deploy/`; `pyproject.toml` declares the package, scripts, dependencies, and tool configs; `requirements.txt` is removed.
+- [ ] **TOOL-03**: `ruff check` and `ruff format --check` pass with zero findings on the v2.0 source tree; CI fails on violations.
+- [ ] **TOOL-04**: `mypy --strict src/` passes with zero errors; CI fails on regressions.
+- [ ] **TOOL-05**: `pre-commit` runs `ruff`, `ruff format`, `mypy`, and `pytest -q --no-cov` on staged changes locally; identical checks run in CI.
+- [ ] **TOOL-06**: `pytest --cov=src/aws_eks_helm_deploy --cov-branch --cov-fail-under=100` passes on every PR (no exceptions; `# pragma: no cover` reviewed in PR).
+- [ ] **TOOL-07**: D can run a full integration test against a real Helm install on a local `kind` cluster with one command (`make integration-test` or `uv run pytest tests/integration`).
+- [ ] **TOOL-08**: D can run the acceptance test suite by building the image and spawning it with `docker run` (parity with existing v1 acceptance pattern, ported to `pytest`).
+
+### AWS Authentication (AUTH)
+
+- [ ] **AUTH-01**: M can authenticate using static `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (parity with v1.x).
+- [ ] **AUTH-02**: M can additionally assume an IAM role by setting `ROLE_ARN` (and optional `SESSION_NAME`), composable on top of any base credential source (parity with v1.x).
+- [ ] **AUTH-03**: M can authenticate via Bitbucket Pipelines OIDC by setting only `OIDC_AUDIENCE` and `ROLE_ARN`; the pipe exchanges `BITBUCKET_STEP_OIDC_TOKEN` for STS credentials via `AssumeRoleWithWebIdentity`. **(Closes #3.)**
+- [ ] **AUTH-04**: When both static keys and an OIDC token are present, OIDC wins (deterministic strategy selection).
+- [ ] **AUTH-05**: The pipe ships a documented AWS IAM trust-policy template scoped to `BITBUCKET_WORKSPACE_UUID` and `BITBUCKET_REPO_UUID` so consumers cannot accidentally configure a permissive policy. **(Pitfall #1.)**
+- [ ] **AUTH-06**: The pipe rejects misconfigurations explicitly (e.g. `ROLE_ARN` set without any base credentials, `OIDC_AUDIENCE` without `ROLE_ARN`) with a clear error message before contacting AWS.
+- [ ] **AUTH-07**: The EKS token (`k8s-aws-v1.<base64url-presigned-STS-URL>`) is generated via `boto3` only; no `awscli` dependency in the runtime image.
+
+### Helm Chart Sources (CHART)
+
+- [ ] **CHART-01**: M can deploy a Helm chart from a local path (parity with v1.x).
+- [ ] **CHART-02**: M can deploy a chart from a Helm repository by setting `CHART=repo://<repo-name>/<chart>`, `REPO_URL=<url>`, optional `CHART_VERSION=<version>`. **(Closes #7.)**
+- [ ] **CHART-03**: M can deploy a chart from an OCI registry by setting `CHART=oci://<registry>/<chart>` with optional `CHART_VERSION` and optional `REGISTRY_USERNAME` + `REGISTRY_PASSWORD`.
+- [ ] **CHART-04**: M can verify an OCI chart signature by setting `CHART_VERIFY=true` (Cosign verification of the chart artifact); failure aborts the upgrade.
+- [ ] **CHART-05**: The pipe reports the resolved chart name + version in its success message so the consumer's logs are unambiguous.
+
+### Pipe Actions (PIPE)
+
+- [ ] **PIPE-01**: `ACTION=upgrade` (default) runs `helm upgrade --install` with the resolved chart source and credentials.
+- [ ] **PIPE-02**: `ACTION=diff` (or shortcut `DRY_RUN=true` on an upgrade) runs `helm diff upgrade` via the bundled `helm-diff` plugin and surfaces the diff to stdout without mutating the cluster.
+- [ ] **PIPE-03**: When `ACTION=diff` runs in a Bitbucket Pull-Request build (`$BITBUCKET_PR_ID` set) and `POST_DIFF_AS_COMMENT=true`, the diff is posted as a PR comment via the Bitbucket REST API using `BITBUCKET_TOKEN`. **(Differentiator #3.)**
+- [ ] **PIPE-04**: `ACTION=rollback` with `REVISION=<n>` runs `helm rollback <release> <revision>` against the cluster.
+- [ ] **PIPE-05**: When `SAFE_UPGRADE=true`, the pipe passes both `--wait` and `--atomic` to `helm upgrade --install`, and pre-flight-checks `helm history <release>` before any rollback to detect revisions that were not `--wait`-ed. **(Pitfall #3.)**
+- [ ] **PIPE-06**: Every action returns a non-zero exit code on failure with a human-readable failure message via the `bitbucket-pipes-toolkit` `fail()` channel.
+
+### Helm Release History (HISTORY)
+
+- [ ] **HISTORY-01**: M can set `HISTORY_MAX=<n>` (default unset, meaning Helm default of 10) to bound the release history retained by Helm. **(Closes #17.)**
+- [ ] **HISTORY-02**: When `HISTORY_MAX` is set, the pipe passes `--history-max <n>` to `helm upgrade --install`.
+
+### Bitbucket Metadata Injection (META)
+
+- [ ] **META-01**: When `INJECT_BITBUCKET_METADATA=true`, the pipe injects `--set bitbucket.bitbucket_build_number=…`, `bitbucket.bitbucket_repo_slug=…`, `bitbucket.bitbucket_commit=…`, `bitbucket.bitbucket_tag=…`, `bitbucket.bitbucket_step_triggerer_uuid=…` (v1.x parity behavior).
+- [ ] **META-02**: When `INJECT_BITBUCKET_METADATA` is unset or `false` (the v2.0 default), no `bitbucket.*` values are injected. **(Closes #16; breaking change vs v1.x.)**
+- [ ] **META-03**: When the pipe detects that a chart's `values.yaml` references `.Values.bitbucket.*` and `INJECT_BITBUCKET_METADATA` is not explicitly set, it logs a loud one-time warning recommending the consumer set it explicitly. **(Pitfall #2 mitigation.)**
+
+### Container Image (IMAGE)
+
+- [ ] **IMAGE-01**: The image is built from `python:3.13-slim-bookworm` as the base; Alpine is not used.
+- [ ] **IMAGE-02**: The image bundles Helm 3.18.x and the `helm-diff` 3.10.x plugin.
+- [ ] **IMAGE-03**: The image runs as a non-root user (`USER pipe` with uid ≥ 10000).
+- [ ] **IMAGE-04**: The image is built for both `linux/amd64` and `linux/arm64` and published as a single multi-arch manifest; native ARM runners are used (no QEMU). **(Pitfall #5.)**
+- [ ] **IMAGE-05**: The image carries OCI annotations: `org.opencontainers.image.source`, `…revision`, `…version`, `…licenses` (`Apache-2.0`), `…title`, `…description`.
+- [ ] **IMAGE-06**: A documented cold-start benchmark (image pull excluded) is published in the README; v2.0 target is under 10 seconds on a Bitbucket-Pipelines-equivalent runner.
+
+### Supply-Chain Security (SEC)
+
+- [ ] **SEC-01**: Every release image is **signed with Cosign keyless** via GitHub Actions OIDC → Fulcio → Rekor; the signature includes an offline bundle (`--bundle`). **(Pitfall #4.)**
+- [ ] **SEC-02**: Each release image carries an **SBOM** generated by Syft in **both SPDX and CycloneDX** formats, attached as Cosign attestations.
+- [ ] **SEC-03**: Each release image carries a **SLSA build provenance** attestation via `actions/attest-build-provenance@v1`.
+- [ ] **SEC-04**: `trivy` scans the built image, Dockerfile, Helm chart fixtures, and secret-leak patterns on every PR; CI fails on `CRITICAL` or `HIGH` findings unless suppressed in `.trivyignore` with rationale.
+- [ ] **SEC-05**: `pip-audit` runs on every PR; CI fails on any unsuppressed vulnerability.
+- [ ] **SEC-06**: Helm output emitted by the pipe (logs, PR comments, debug dumps) **masks `kind: Secret` rendered manifests** — replacing the entire `data:`/`stringData:` payload with `<redacted>`. **(Pitfall TS-9 in PITFALLS.md; precondition for PIPE-03.)**
+
+### CI / Release (CI)
+
+- [ ] **CI-01**: A GitHub Actions workflow (`.github/workflows/ci.yml`) runs `ruff`, `mypy`, `pytest --cov`, `trivy`, and `pip-audit` on every PR; required status checks gate merge into `main`.
+- [ ] **CI-02**: A GitHub Actions workflow (`.github/workflows/release.yml`) is driven by `release-please` (v4, `release-type: python`); a release-PR updates `pyproject.toml`, `CHANGELOG.md`, and `pipe.yml` image-tag in a single commit.
+- [ ] **CI-03**: On `main` after a release-PR merge, the workflow builds the multi-arch image, signs it with Cosign, attaches SBOM + provenance, and pushes to **both** `ghcr.io/yves-vogl/aws-eks-helm-deploy` and `docker.io/yvogl/aws-eks-helm-deploy`.
+- [ ] **CI-04**: A separate, minimal `bitbucket-pipelines.yml` continues to publish the Bitbucket Pipe Marketplace listing on tagged releases; GitHub Actions is the source-of-truth for image builds.
+- [ ] **CI-05**: Dependabot (`.github/dependabot.yml`) is configured for `pip`, `docker`, and `github-actions`; auto-merge is enabled for all updates (including majors) once CI passes — tests are the gate.
+- [ ] **CI-06**: Every commit on `main` is GPG-signed (verified on GitHub); branch protection enforces signed commits.
+- [ ] **CI-07**: Branch protection on `main`: signed commits, required review (1+), required status checks, no direct pushes.
+
+### Observability & Logging (OBS)
+
+- [ ] **OBS-01**: The pipe emits **structured log lines** (one JSON object per line on stderr when `LOG_FORMAT=json`, otherwise human-readable) with stable field names: `action`, `cluster`, `release`, `namespace`, `chart_source`, `auth_strategy`, `duration_ms`.
+- [ ] **OBS-02**: `DEBUG=true` (parity with v1.x) raises verbosity to include full helm argv, resolved credentials source (never the credentials themselves), and per-phase timings.
+
+### Documentation (DOC)
+
+- [ ] **DOC-01**: The `README.md` is the entry doc: badge row, 60-second quick-start, link to the docs site for everything else.
+- [ ] **DOC-02**: An `mkdocs-material` site is published to GitHub Pages with `mike` providing `/v1/` (frozen v1.3.0 reference) and `/v2/` (current).
+- [ ] **DOC-03**: A `Migration Guide v1 → v2` documents every breaking change: `INJECT_BITBUCKET_METADATA` default, removed/renamed env vars, image-tag pinning policy, recommended `latest` policy (pinned to v1.3.0 forever).
+- [ ] **DOC-04**: ADRs live under `docs/adr/` (MADR template). At minimum: forge primacy (GitHub), v2.0 clean break, Cosign keyless over GPG, `boto3`-only over `awscli`, `release-please` over `semversioner`, OIDC default behavior, multi-arch via native runners.
+- [ ] **DOC-05**: `CONTRIBUTING.md` documents the `uv sync` / `pre-commit` / `pytest` / `kind` development loop and the Conventional-Commits rule.
+- [ ] **DOC-06**: `SECURITY.md` documents the private disclosure flow (email or GitHub security advisory) and the supported-version policy (v2.x current; v1.x receives security fixes for 6 months post-v2.0).
+- [ ] **DOC-07**: `CODE_OF_CONDUCT.md` adopts the Contributor Covenant 2.1.
+- [ ] **DOC-08**: An `examples/` directory ships ≥4 end-to-end `bitbucket-pipelines.yml` snippets: basic, OIDC-only, OCI chart from GHCR, multi-environment deploy with `helm-diff` PR comment.
+
+### Community Ops (CMN)
+
+- [ ] **CMN-01**: `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` are present; both require pipe version, runtime context, and reproduction.
+- [ ] **CMN-02**: `.github/PULL_REQUEST_TEMPLATE.md` lists the merge checklist: tests added, `CHANGELOG`/`release-please` entry, docs updated, ADR if architecturally relevant.
+- [ ] **CMN-03**: A GitHub Project (board) tracks the v2.0 milestone in `Backlog → Ready → In Progress → In Review → Done` columns; auto-linked to the `v2.0.0` milestone.
+- [ ] **CMN-04**: The label taxonomy (`area/*`, `type/*`, `priority/*`, `breaking-change`, `good first issue`, `help wanted`) is applied to every open issue and PR.
+
+### Migration v1 → v2 (MIG)
+
+- [ ] **MIG-01**: The Docker Hub `:latest` tag is **frozen at v1.3.0** before the first v2.0 image is published; a documented `:2` rolling tag is introduced for v2 consumers who want major-version-pinned auto-updates.
+- [ ] **MIG-02**: The first v2.0 image emits a loud one-time deprecation warning at startup if it detects v1-only env-var names (`SET`/`VALUES` in the older positional format, or charts referencing `.Values.bitbucket.*` without `INJECT_BITBUCKET_METADATA=true`).
+- [ ] **MIG-03**: An `examples/migration-v1-to-v2/` directory contains a before/after `bitbucket-pipelines.yml` diff with line-level explanations of every required change.
+
+## v2 (Deferred) Requirements
+
+These are acknowledged but explicitly **not in the v2.0 scope** — tracked for v2.1+:
+
+### Auth (v2.1+)
+- **AUTH-NEXT-01**: AWS Pod Identity support for self-hosted Bitbucket Pipelines runners on EKS.
+- **AUTH-NEXT-02**: `aws-vault` integration for self-hosted Mac/Linux runners.
+
+### Pipe Actions (v2.1+)
+- **PIPE-NEXT-01**: `ACTION=uninstall` (`helm uninstall`) with `KEEP_HISTORY=true` opt-in.
+- **PIPE-NEXT-02**: `ACTION=lint` (`helm lint`) for PR-time chart validation.
+
+### Distribution (v2.1+)
+- **CI-NEXT-01**: Reusable GitHub Action wrapper so the same pipe code can also be invoked from GitHub Actions (consumer convenience; the project remains Bitbucket-first).
+
+### Documentation site (v2.1+)
+- **DOC-NEXT-01**: Migrate from `mkdocs-material` to `Zensical` once stable (mkdocs-material entered maintenance mode in early 2026).
+
+## Out of Scope
+
+Explicit boundaries. Anti-features carry reasoning so re-adding requires explicit revisit.
+
+| Feature | Reason |
+|---------|--------|
+| **First-party GitHub Actions invocation surface** | This is a Bitbucket Pipe. GH Actions consumers are pointed at `aws-actions/configure-aws-credentials` + a Helm action. Turning this into an Action is a different project. |
+| **Multi-cluster atomic deploy in one pipe call** | Composability via multiple steps in `bitbucket-pipelines.yml` is sufficient. Adds reconciliation complexity (rollback semantics across clusters) without proportionate value. |
+| **GitOps reconciliation (drift detection, sync loops)** | This is what Flux/ArgoCD are for. Our pipe owns the "best-in-class one-shot CI deploy" position, not "worse imitation of a GitOps controller". |
+| **Helmfile-style multi-release manifest** | Composability via multiple pipe steps is sufficient and avoids inventing a second DSL on top of Helm. |
+| **Templated chart generation** | The pipe deploys charts, it doesn't author them. Out of scope and out of intent. |
+| **Web frontend / GUI** | This is a CI Pipe (a container with env vars). |
+| **Self-hosting Helm chart of this pipe** | The pipe is a CLI-style container, not a long-running service. |
+| **GPG signing of Docker images** | Replaced by Cosign keyless. GPG image signing is dead-tech in OCI distribution. |
+| **`semversioner`-managed releases** | Replaced by `release-please` for tighter Conventional-Commits + GitHub-native release flow; eliminates `.changes/` ceremony. |
+| **Continued `awscli` dependency** | Dropped in v2.0. `boto3`-only EKS token generation is ~40 lines and saves ~120 MB of image weight. Documented in the migration guide. |
+| **Alpine base image** | `python:3.13-slim-bookworm` chosen. musl-libc breaks `boto3` wheel availability and slows builds. |
+| **QEMU multi-arch build** | Native ARM runners only. QEMU silently produces broken `arm64` images that are invisible from Bitbucket's amd64-only acceptance tests. |
+| **Long-lived AWS credentials in the image or pipe code** | OIDC keyless flow is the production path; static keys remain a fallback for legacy consumers only. |
+
+## Traceability
+
+Empty initially. Populated by `gsd-roadmapper` when ROADMAP.md is generated.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| TOOL-01..08 | TBD | Pending |
+| AUTH-01..07 | TBD | Pending |
+| CHART-01..05 | TBD | Pending |
+| PIPE-01..06 | TBD | Pending |
+| HISTORY-01..02 | TBD | Pending |
+| META-01..03 | TBD | Pending |
+| IMAGE-01..06 | TBD | Pending |
+| SEC-01..06 | TBD | Pending |
+| CI-01..07 | TBD | Pending |
+| OBS-01..02 | TBD | Pending |
+| DOC-01..08 | TBD | Pending |
+| CMN-01..04 | TBD | Pending |
+| MIG-01..03 | TBD | Pending |
+
+**Coverage:**
+- v1 requirements: **57** total
+- Mapped to phases: 0 (pending roadmap)
+- Unmapped: 57 ⚠️ (expected — will be 0 after roadmap creation)
+
+---
+*Requirements defined: 2026-06-16*
+*Last updated: 2026-06-16 after initialization*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,148 @@
+# Roadmap: aws-eks-helm-deploy v2.0
+
+## Overview
+
+v2.0 is the state-of-the-art modernization of an existing, in-production Bitbucket Pipelines Pipe (v1.3.0 on Docker Hub, 9+ public consumers). The journey is brownfield: we keep v1.x frozen on Docker Hub forever and ship v2.0 as a clean break. We bootstrap a modern Python toolchain first, then port the auth and helm layers behind typed Protocols (no behavior change), then layer the new v2 features (OIDC, OCI/repo charts, dry-run with PR comments, rollback, opt-in metadata) on top. Supply-chain modernization (multi-arch, Cosign keyless, SBOM, SLSA provenance, Trivy, pip-audit, release-please, GitHub Actions as the release source-of-truth) ships in one combined phase. A versioned `mkdocs-material` site with `mike` and a line-level v1→v2 migration guide is the final phase before tag-cut.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [ ] **Phase 1: Toolchain & Spine** - `uv`/`ruff`/`mypy --strict`/`pytest`/`src/` layout, base Dockerfile, settings/logging/errors/pipe_io skeleton
+- [ ] **Phase 2: AWS Layer & Auth Foundation** - drop `awscli`, pure-`boto3` EKS token gen, `AuthStrategy` Protocol with static-keys + assume-role (v1 parity)
+- [ ] **Phase 3: Helm Core & Upgrade Action** - `HelmClient`, kubeconfig writer, `UpgradeAction`, local-path charts, `HISTORY_MAX`, v1-style metadata injection (v1 feature parity reached)
+- [ ] **Phase 4: OIDC & Chart Source Extensions** - OIDC strategy + IAM trust template, `ChartSource` Protocol with repo + OCI sources + Cosign verify
+- [ ] **Phase 5: Log Masking, Diff, Rollback & Metadata Flip** - `SEC-06` log redaction first, then `DiffAction` + PR-comment poster, `RollbackAction` + `SAFE_UPGRADE`, opt-in metadata default flip with v1 deprecation warning
+- [ ] **Phase 6: Release Pipeline & Supply Chain** - GitHub Actions CI + release-please, multi-arch native-runner build, Cosign keyless, SBOM, SLSA provenance, Trivy + pip-audit, Dependabot, branch protection, community ops
+- [ ] **Phase 7: Documentation Site & Migration Guide** - `mkdocs-material` + `mike` v1/v2 spaces, ADRs, examples, `README` rewrite, line-level v1→v2 migration guide
+
+## Phase Details
+
+### Phase 1: Toolchain & Spine
+**Goal**: A maintainer can clone the repo, run `uv sync --all-extras`, and get green `ruff`, `mypy --strict`, and `pytest` (with placeholder modules); the base Dockerfile builds for `linux/amd64` from `python:3.13-slim-bookworm` with OCI annotations and non-root user.
+**Depends on**: Nothing (first phase)
+**Requirements**: TOOL-01, TOOL-02, TOOL-03, TOOL-04, TOOL-05, TOOL-06, TOOL-07, TOOL-08, IMAGE-01, IMAGE-02, IMAGE-03, IMAGE-05, OBS-01, OBS-02
+**Success Criteria** (what must be TRUE):
+  1. `uv sync --all-extras` completes in under 10 seconds on a warm cache and produces a `.venv/` with all dev tools (TOOL-01).
+  2. `ruff check`, `ruff format --check`, and `mypy --strict src/` exit 0 on the v2 source tree; `pre-commit run --all-files` runs the same checks locally (TOOL-03, TOOL-04, TOOL-05).
+  3. `pytest --cov=src/aws_eks_helm_deploy --cov-branch --cov-fail-under=100` exits 0 on the placeholder skeleton; an integration target (`make integration-test` or `uv run pytest tests/integration`) provisions `kind` and runs at least one helm-on-cluster smoke test; the acceptance tier builds the image and runs `docker run` against it (TOOL-06, TOOL-07, TOOL-08).
+  4. `docker build` produces a `linux/amd64` image from `python:3.13-slim-bookworm` with Helm 3.18.x + `helm-diff` 3.10.x bundled, running as `USER pipe` (uid ≥ 10000), with OCI annotations (`source`, `revision`, `version`, `licenses=Apache-2.0`, `title`, `description`) set via `buildx --annotation` (IMAGE-01, IMAGE-02, IMAGE-03, IMAGE-05).
+  5. The pipe entrypoint emits human-readable logs by default and one JSON object per line on stderr when `LOG_FORMAT=json`, with stable field names (`action`, `cluster`, `release`, `namespace`, `chart_source`, `auth_strategy`, `duration_ms`); `DEBUG=true` raises verbosity to include resolved auth source and per-phase timings without leaking credentials (OBS-01, OBS-02).
+**Plans**: TBD
+**Risks**:
+  - `uv` lockfile drift between local dev and CI (PITFALLS-style supply-chain risk). Mitigation: CI runs `uv sync --frozen` only; `uv.lock` must be committed and is gated by Dependabot.
+  - `mypy --strict` plus `boto3-stubs` is famously noisy on first contact. Mitigation: scope strict mode to `src/` only on day one; defer `tests/` strictness to a follow-up plan inside Phase 1 if needed.
+  - The `src/`-layout migration accidentally drops a v1 import path that a consumer's vendored fork relied on. Mitigation: v2.0 is a clean break — the migration guide (Phase 7) documents this explicitly; no compat shims.
+
+### Phase 2: AWS Layer & Auth Foundation
+**Goal**: The pipe authenticates to AWS using static keys and optional `ROLE_ARN` assumption through a typed `AuthStrategy` Protocol; EKS tokens are generated by pure `boto3` only; `awscli` is fully removed from the image. Functional parity with v1.x, new architecture.
+**Depends on**: Phase 1
+**Requirements**: AUTH-01, AUTH-02, AUTH-07
+**Success Criteria** (what must be TRUE):
+  1. `src/aws_eks_helm_deploy/auth/base.py` defines the `AuthStrategy` Protocol and `AwsCredentials` value object; `static_keys.py` and `assume_role.py` are independent classes; `auth/__init__.py::select_strategy(settings)` composes `AssumeRoleStrategy` on top of any base strategy (AUTH-01, AUTH-02).
+  2. `src/aws_eks_helm_deploy/aws/eks_token.py` generates a `k8s-aws-v1.<base64url-presigned-STS-URL>` token using only `boto3` (no `awscli`, no `awscli.customizations.eks.get_token` import); a golden unit test asserts the produced token equals `aws eks get-token` reference output byte-for-byte (AUTH-07).
+  3. `pyproject.toml` declares `boto3` and removes `awscli`; `docker history` of the built image shows no `awscli` layer; runtime image size is measurably smaller than v1.x (target: > 100 MB reduction).
+  4. Unit-test coverage is 100% line+branch for `auth/` and `aws/` modules (mocked via `moto` and `pytest-mock`); a `kind`-backed integration test proves `StaticKeysStrategy` + `AssumeRoleStrategy` produce a kubeconfig that `helm` accepts.
+**Plans**: TBD
+**Risks**:
+  - EKS token format is undocumented as a stable contract; the presigned-URL 15-minute exclusive cluster-name header is easy to get wrong. Mitigation: golden test against `aws eks get-token` output on every PR; reference the `aws-iam-authenticator` repo header format.
+  - `boto3` STS `assume_role` regional endpoint defaults differ from `awscli`. Mitigation: pin `AWS_STS_REGIONAL_ENDPOINTS=regional` explicitly in session config; document in CHANGELOG.
+  - The `AuthStrategy` Protocol must accommodate OIDC in Phase 4 without refactor. Mitigation: design review at end of Phase 2 — write OIDC strategy *signature* (not impl) as a compile-only stub to prove the Protocol holds.
+
+### Phase 3: Helm Core & Upgrade Action
+**Goal**: `ACTION=upgrade` (default) deploys a local-path Helm chart to a real EKS cluster end-to-end via the new typed `HelmClient`, honouring `HISTORY_MAX` and v1-style Bitbucket metadata injection. v1.x functional parity is reached on the new architecture. Closes issue #17.
+**Depends on**: Phase 2
+**Requirements**: CHART-01, CHART-05, PIPE-01, PIPE-06, HISTORY-01, HISTORY-02, META-01
+**Success Criteria** (what must be TRUE):
+  1. `src/aws_eks_helm_deploy/kube/kubeconfig.py` writes a tempfile kubeconfig (context-managed, deleted on exit) from a `ClusterAccess` + `EksAuthToken`; `helm/client.py` is the only module that calls `subprocess.run` and exposes one typed method per helm subcommand (`upgrade_install`, `history`); `actions/upgrade.py` is < 50 lines and calls exactly one `HelmClient` method (CHART-01, PIPE-01).
+  2. An integration test against `kind` deploys a minimal chart from a local path, asserts the success message contains the resolved chart name + version (CHART-05), and the exit code is 0; an induced helm failure surfaces via `bitbucket-pipes-toolkit.fail()` with a non-zero exit code and human-readable message (PIPE-06).
+  3. When `HISTORY_MAX=5` is set, `helm history <release>` in the cluster returns at most 5 revisions after 6 upgrade rounds; when unset, default-10 behavior holds (HISTORY-01, HISTORY-02). Closes #17.
+  4. When `INJECT_BITBUCKET_METADATA=true` and `BITBUCKET_BUILD_NUMBER`/etc. are set, the rendered chart receives `--set bitbucket.bitbucket_build_number=…` for all five documented keys; assertion via `helm get values <release>` in an integration test (META-01).
+**Plans**: TBD
+**Risks**:
+  - `subprocess.run` timeouts and Helm Go-duration parsing have v1.x edge cases that the new typed wrapper might re-introduce. Mitigation: snapshot tests with `syrupy` on argv generation; preserve the existing v1 timeout-handling regression cases as integration fixtures.
+  - `kind` cluster startup in CI is flaky on cold runners. Mitigation: cache `kind` node image; retry cluster creation up to 3 times; mark flake patterns explicitly with `pytest-rerunfailures`.
+  - Helm release-history coupling with future rollback (Phase 5) — pruning too aggressively breaks rollback. Mitigation: document `HISTORY_MAX` ≥ rollback-target depth in the variable reference; warn in Phase 5 when `HISTORY_MAX < REVISION + 1`.
+
+### Phase 4: OIDC & Chart Source Extensions
+**Goal**: Consumers can authenticate via Bitbucket Pipelines OIDC (zero static keys) and pull charts from Helm repos or OCI registries with optional Cosign signature verification. Closes issues #3 and #7.
+**Depends on**: Phase 3
+**Requirements**: AUTH-03, AUTH-04, AUTH-05, AUTH-06, CHART-02, CHART-03, CHART-04
+**Success Criteria** (what must be TRUE):
+  1. `src/aws_eks_helm_deploy/auth/oidc.py` adds `OidcWebIdentityStrategy`; when both `BITBUCKET_STEP_OIDC_TOKEN` and static keys are present, OIDC wins deterministically (AUTH-03, AUTH-04); misconfigurations (`ROLE_ARN` without base creds, `OIDC_AUDIENCE` without `ROLE_ARN`) raise `ConfigurationError` with a clear message before any AWS API call (AUTH-06).
+  2. `docs/guides/oidc-setup.md` (drafted here, polished in Phase 7) ships an IAM trust-policy template that constrains `aud` and `sub` to `BITBUCKET_WORKSPACE_UUID:{uuid}` and `BITBUCKET_REPO_UUID:{uuid}`; a unit test asserts the template is valid JSON and references both UUIDs (AUTH-05).
+  3. `src/aws_eks_helm_deploy/chart/base.py` defines `ChartSource` Protocol + `ResolvedChart` dataclass; `local.py`, `repo.py`, and `oci.py` are independent; `CHART=repo://name/chart` + `REPO_URL` + `CHART_VERSION` runs `helm repo add` before upgrade (CHART-02); `CHART=oci://registry/chart` + optional `REGISTRY_USERNAME`/`PASSWORD` + `CHART_VERSION` pulls via `helm pull oci://…` (CHART-03).
+  4. `CHART_VERIFY=true` invokes Cosign verification of the OCI chart artifact; a failed signature aborts the upgrade with `ChartResolutionError` exit code (CHART-04); integration test uses a local `registry:2` container and a signed test chart.
+**Plans**: TBD
+**Risks**:
+  - Bitbucket OIDC trust policy under-constrained (Pitfall #1). Mitigation: ship the IAM template with explicit `aud`/`sub` UUIDs; add a `terraform` snippet; surface a warning in the pipe log if the IAM role's trust policy can be introspected and is found permissive (best-effort).
+  - OCI auth state leaking into `~/.docker/config.json` past invocation. Mitigation: use `helm registry login` only with `HELM_REGISTRY_CONFIG` pointed at the tempfile dir; cleanup on exit.
+  - Cosign chart-verify path expands the runtime image size and pulls a new binary. Mitigation: install `cosign` in the same multi-stage builder as `helm`; verify cold-start budget is still under 10s with an explicit benchmark in CI.
+
+### Phase 5: Log Masking, Diff, Rollback & Metadata Flip
+**Goal**: Helm output emitted by the pipe never leaks `Secret` payloads; consumers can preview changes via `ACTION=diff` (or `DRY_RUN=true`) and optionally post the diff as a Bitbucket PR comment; `ACTION=rollback` is safe by default; `INJECT_BITBUCKET_METADATA` defaults to `false` (breaking change) with a loud deprecation warning when v1-style chart usage is detected. Closes issue #16 and addresses Pitfalls #2 and #3.
+**Depends on**: Phase 4
+**Requirements**: SEC-06, PIPE-02, PIPE-03, PIPE-04, PIPE-05, META-02, META-03, MIG-02
+**Success Criteria** (what must be TRUE):
+  1. The log-masking subsystem replaces the entire `data:`/`stringData:` block of any rendered `kind: Secret` manifest with `<redacted>` before the bytes leave the pipe (logs, stdout, PR comments); a unit test feeds a chart that emits Secrets and asserts no secret bytes appear in any captured output stream; this lands before any PIPE-03 wiring (SEC-06).
+  2. `ACTION=diff` (or `DRY_RUN=true` on upgrade) runs `helm diff upgrade` via the bundled `helm-diff` 3.10 plugin and prints a colored diff to stdout without mutating the cluster (PIPE-02); when `$BITBUCKET_PR_ID` is set and `POST_DIFF_AS_COMMENT=true`, the (masked) diff is posted as a PR comment via the Bitbucket REST API using `BITBUCKET_TOKEN`; integration test asserts the API was called with the masked payload (PIPE-03).
+  3. `ACTION=rollback` + `REVISION=<n>` invokes `helm rollback <release> <n>` (PIPE-04); when `SAFE_UPGRADE=true`, both `--wait` and `--atomic` are passed to upgrade and a pre-flight `helm history` check fails the action if the target revision was not deployed with `--wait` (PIPE-05).
+  4. With `INJECT_BITBUCKET_METADATA` unset, no `bitbucket.*` values are injected (META-02 — breaking change vs v1); when the pipe detects the chart's `values.yaml` references `.Values.bitbucket.*` without `INJECT_BITBUCKET_METADATA` set, it logs a loud one-time WARN recommending explicit opt-in (META-03); v1-only env-var names (`SET` / `VALUES` in positional format) trigger a one-time deprecation warning at startup (MIG-02). Closes #16.
+**Plans**: TBD
+**Risks**:
+  - Log masking misses a non-stdlib Helm output channel (e.g., `helm get manifest` consumed by a future feature). Mitigation: centralize the redactor in `helm/redact.py`; every `HelmClient` method routes captured output through it; a fuzz test feeds randomised chart fixtures.
+  - The PR-comment poster leaks credentials in error paths if Bitbucket API returns 4xx. Mitigation: error handler scrubs `BITBUCKET_TOKEN` from any logged response body; integration test asserts an injected 401 response surfaces no token bytes.
+  - `--atomic` + `HISTORY_MAX` interaction (Pitfall #3): a `--wait`-less prior revision breaks rollback target. Mitigation: `SAFE_UPGRADE` couples both flags; pre-flight `helm history` rejects rollback to unsafe revisions; documented in migration guide.
+
+### Phase 6: Release Pipeline & Supply Chain
+**Goal**: Every push to `main` produces a release-please PR that, when merged, builds a multi-arch (`linux/amd64` + `linux/arm64`) image on native runners, signs it with Cosign keyless, attaches SBOM (SPDX + CycloneDX) and SLSA provenance, runs Trivy + pip-audit as required PR gates, and pushes to both GHCR and Docker Hub. Bitbucket-side becomes a thin mirror that only re-publishes the marketplace listing. Dependabot, branch protection, GPG-signed commits, issue/PR templates, GH Project board, and the label taxonomy are all live. Docker Hub `:latest` is frozen at v1.3.0; `:2` becomes the rolling v2 major tag.
+**Depends on**: Phase 5
+**Requirements**: IMAGE-04, IMAGE-06, SEC-01, SEC-02, SEC-03, SEC-04, SEC-05, CI-01, CI-02, CI-03, CI-04, CI-05, CI-06, CI-07, CMN-01, CMN-02, CMN-03, CMN-04, MIG-01
+**Success Criteria** (what must be TRUE):
+  1. `.github/workflows/ci.yml` runs `ruff`, `mypy`, `pytest --cov`, `trivy` (image + Dockerfile + chart fixtures + secret-leak), and `pip-audit` on every PR; required status checks gate merge into `main`; CI fails on Trivy `CRITICAL`/`HIGH` unless suppressed in `.trivyignore` with rationale; CI fails on any unsuppressed `pip-audit` finding (CI-01, SEC-04, SEC-05).
+  2. `.github/workflows/release.yml` is driven by `googleapis/release-please-action@v4` (`release-type: python`); a release-PR atomically updates `pyproject.toml`, `CHANGELOG.md`, and `pipe.yml` image-tag; on release-PR merge the workflow builds a multi-arch manifest on a native-runner matrix (`ubuntu-24.04` for amd64, `ubuntu-24.04-arm` for arm64 — no QEMU), signs with `cosign sign --bundle` (keyless via GitHub OIDC → Fulcio → Rekor), attaches Syft SBOM in **both** SPDX and CycloneDX, attaches `actions/attest-build-provenance@v1` SLSA provenance, and pushes the manifest to both `ghcr.io/yves-vogl/aws-eks-helm-deploy` and `docker.io/yvogl/aws-eks-helm-deploy` (CI-02, CI-03, IMAGE-04, SEC-01, SEC-02, SEC-03).
+  3. A documented cold-start benchmark (`scripts/benchmark-cold-start.sh`, run in CI, results in README badge) reports under 10 seconds on a GitHub-hosted runner with the image pre-pulled (IMAGE-06); `docker buildx imagetools inspect` of the released manifest shows two real arches (no QEMU layers).
+  4. `.github/dependabot.yml` configures `pip`, `docker`, and `github-actions` weekly; `dependabot-auto-merge.yml` workflow auto-merges PRs (including major bumps) once required checks pass (CI-05); branch protection on `main` requires signed commits, 1+ review, required status checks, and disallows direct pushes; all commits on `main` are GPG-verified (CI-06, CI-07).
+  5. `.github/ISSUE_TEMPLATE/bug_report.yml` + `feature_request.yml` require pipe version + runtime context + repro; `PULL_REQUEST_TEMPLATE.md` lists the merge checklist (tests, release-please entry, docs, ADR); the v2.0.0 GitHub Project board has `Backlog → Ready → In Progress → In Review → Done` columns auto-linked to the milestone; every open issue and PR carries `area/*`, `type/*`, `priority/*`, `breaking-change`, `good first issue`, `help wanted` labels per taxonomy (CMN-01, CMN-02, CMN-03, CMN-04).
+  6. A minimal `bitbucket-pipelines.yml` continues to publish the Bitbucket Pipe Marketplace listing on tagged releases without building or pushing images (CI-04); the Docker Hub `:latest` tag is pinned to v1.3.0 *before* any v2.0 image is pushed; a documented `:2` rolling tag is introduced for major-pinned v2 consumers (MIG-01).
+**Plans**: TBD
+**Risks**:
+  - Cosign keyless three-way coupling (Pitfall #4): missing `id-token: write` permission at job inheritance, Rekor unavailability at verify time, Fulcio cert expiry mid-job. Mitigation: declare `permissions: id-token: write` at workflow level; always `cosign sign --bundle`; isolate signing in a short-lived job; verify-on-PR step on every release-please PR.
+  - Multi-arch via QEMU silently produces broken arm64 (Pitfall #5). Mitigation: native ARM runners only (`ubuntu-24.04-arm`); `docker buildx imagetools inspect` post-build smoke test asserts both arches are present as real platforms; base image pinned by digest.
+  - Dependabot auto-merge on majors lands a breaking transitive dependency. Mitigation: test-gate is the merge criterion; the 100% coverage requirement + integration + acceptance tiers detect behavioral regressions; rollback via revert-and-pin path documented in `CONTRIBUTING.md`.
+
+### Phase 7: Documentation Site & Migration Guide
+**Goal**: A maintainer landing on the README finds a 60-second quickstart and a link to a versioned `mkdocs-material` site with `/v1/` (frozen v1.3.0 reference) and `/v2/` (current); the migration guide is the headline page and is supported by a line-level before/after `bitbucket-pipelines.yml` diff under `examples/migration-v1-to-v2/`. ADRs cover every architectural decision. This is the final phase before the v2.0.0 tag-cut.
+**Depends on**: Phase 6
+**Requirements**: DOC-01, DOC-02, DOC-03, DOC-04, DOC-05, DOC-06, DOC-07, DOC-08, MIG-03
+**Success Criteria** (what must be TRUE):
+  1. `README.md` is the entry doc: badge row (build, coverage, Docker Hub, GHCR, Cosign-verified), 60-second quickstart with one `bitbucket-pipelines.yml` snippet, and prominent links to the docs site, marketplace listing, and migration guide (DOC-01).
+  2. `mkdocs-material` + `mike` site is deployed to GitHub Pages via `.github/workflows/docs.yml`; `mike list` shows both `v1` (frozen snapshot of v1.3.0 reference) and `v2` (default); the variable reference under `/v2/reference/variables.md` is auto-generated by `scripts/generate-variables-doc.py` from `settings.py` and CI fails if the committed output drifts from the generator (DOC-02).
+  3. `docs/migration/v1-to-v2.md` documents every breaking change (`INJECT_BITBUCKET_METADATA` default flip, removed/renamed env vars, `NAMESPACE` default correction, image-tag pinning policy including the `:latest` freeze + `:2` rolling tag); `examples/migration-v1-to-v2/` contains a before/after `bitbucket-pipelines.yml` diff with line-level explanations (DOC-03, MIG-03).
+  4. `docs/adr/` contains MADR-template ADRs covering at minimum: GitHub primary forge, v2.0 clean break, Cosign keyless over GPG, `boto3`-only over `awscli`, `release-please` over `semversioner`, OIDC default behavior, multi-arch via native runners (DOC-04).
+  5. `CONTRIBUTING.md`, `SECURITY.md` (private disclosure flow + v1.x 6-month support window), and `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) are present at repo root and linked from the docs site (DOC-05, DOC-06, DOC-07); `examples/` ships at least four end-to-end `bitbucket-pipelines.yml` files: basic, OIDC-only, OCI chart from GHCR, multi-env deploy with `helm-diff` PR comment (DOC-08).
+**Plans**: TBD
+**UI hint**: yes
+**Risks**:
+  - `mkdocs-material` entered maintenance mode early 2026; choosing it now invites a future migration to `Zensical`. Mitigation: scoped as a known v2.1+ track (see REQUIREMENTS DOC-NEXT-01); the 12-18 month horizon is acceptable for v2.0.
+  - Variable-reference generator drifts from `settings.py` if a contributor edits the generated file directly. Mitigation: CI step diffs generator output against committed file; PR check fails on drift; banner comment in the generated file warns against manual edits.
+  - The migration guide misses a real-world breaking change discovered post-release. Mitigation: a follow-up "lessons learned" pass in the first 30 days post-v2.0.0 adds any consumer-reported breakage; tracked via the `breaking-change` label on the GH Project board.
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6 → 7
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Toolchain & Spine | 0/TBD | Not started | - |
+| 2. AWS Layer & Auth Foundation | 0/TBD | Not started | - |
+| 3. Helm Core & Upgrade Action | 0/TBD | Not started | - |
+| 4. OIDC & Chart Source Extensions | 0/TBD | Not started | - |
+| 5. Log Masking, Diff, Rollback & Metadata Flip | 0/TBD | Not started | - |
+| 6. Release Pipeline & Supply Chain | 0/TBD | Not started | - |
+| 7. Documentation Site & Migration Guide | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,85 @@
+---
+gsd_state_version: '1.0'
+status: planning
+progress:
+  total_phases: 7
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-06-16)
+
+**Core value:** A maintainer can ship a Bitbucket Pipelines deployment to AWS EKS from a clean repository in under five minutes — without committing static AWS credentials and without surprises at upgrade time.
+**Current focus:** Phase 1 — Toolchain & Spine
+
+## Current Position
+
+Phase: 1 of 7 (Toolchain & Spine)
+Plan: 0 of TBD in current phase
+Status: Ready to plan
+Last activity: 2026-06-16 — Roadmap created; 57/57 v1 requirements mapped across 7 phases
+
+Progress: [░░░░░░░░░░] 0%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 0
+- Average duration: —
+- Total execution time: —
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| - | - | - | - |
+
+**Recent Trend:**
+- Last 5 plans: —
+- Trend: —
+
+*Updated after each plan completion*
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Roadmap: 7-phase structure derived from SUMMARY.md §6 sequencing and ARCHITECTURE.md 10-phase build order, consolidated into 7 to match `granularity: standard`.
+- Roadmap: Log-masking (SEC-06) sequenced before PIPE-03 (PR-comment helm-diff) as hard precondition.
+- Roadmap: Release pipeline + Cosign + SBOM + Trivy + pip-audit + multi-arch consolidated into a single Phase 6 ("Release & Supply Chain") for plan-size economy.
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+None yet.
+
+## Deferred Items
+
+Items acknowledged and carried forward as v2.1+ (see REQUIREMENTS.md "v2 (Deferred) Requirements"):
+
+| Category | Item | Status | Deferred At |
+|----------|------|--------|-------------|
+| Auth | AUTH-NEXT-01 (AWS Pod Identity for self-hosted runners) | Deferred | 2026-06-16 |
+| Auth | AUTH-NEXT-02 (`aws-vault` integration) | Deferred | 2026-06-16 |
+| Pipe Actions | PIPE-NEXT-01 (`ACTION=uninstall`) | Deferred | 2026-06-16 |
+| Pipe Actions | PIPE-NEXT-02 (`ACTION=lint`) | Deferred | 2026-06-16 |
+| Distribution | CI-NEXT-01 (reusable GitHub Action wrapper) | Deferred | 2026-06-16 |
+| Docs | DOC-NEXT-01 (mkdocs-material → Zensical migration) | Deferred | 2026-06-16 |
+
+## Session Continuity
+
+Last session: 2026-06-16
+Stopped at: Roadmap created — 7 phases, 57/57 v1 REQs mapped
+Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -23,7 +23,7 @@ See: .planning/PROJECT.md (updated 2026-06-16)
 Phase: 1 of 7 (Toolchain & Spine)
 Plan: 0 of TBD in current phase
 Status: Ready to plan
-Last activity: 2026-06-16 — Roadmap created; 57/57 v1 requirements mapped across 7 phases
+Last activity: 2026-06-16 — Roadmap created; 67/67 v1 requirements mapped across 7 phases
 
 Progress: [░░░░░░░░░░] 0%
 
@@ -81,5 +81,5 @@ Items acknowledged and carried forward as v2.1+ (see REQUIREMENTS.md "v2 (Deferr
 ## Session Continuity
 
 Last session: 2026-06-16
-Stopped at: Roadmap created — 7 phases, 57/57 v1 REQs mapped
+Stopped at: Roadmap created — 7 phases, 67/67 v1 REQs mapped
 Resume file: None

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,90 @@
+{
+  "model_profile": "balanced",
+  "commit_docs": true,
+  "parallelization": true,
+  "search_gitignored": false,
+  "brave_search": false,
+  "firecrawl": false,
+  "exa_search": false,
+  "tavily_search": false,
+  "ref_search": false,
+  "perplexity": false,
+  "jina": false,
+  "git": {
+    "branching_strategy": "none",
+    "create_tag": true,
+    "phase_branch_template": "gsd/phase-{phase}-{slug}",
+    "milestone_branch_template": "gsd/{milestone}-{slug}",
+    "quick_branch_template": null
+  },
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": true,
+    "auto_advance": true,
+    "node_repair": true,
+    "node_repair_budget": 2,
+    "ui_phase": true,
+    "ui_safety_gate": true,
+    "ai_integration_phase": true,
+    "tdd_mode": false,
+    "human_verify_mode": "end-of-phase",
+    "text_mode": false,
+    "research_before_questions": false,
+    "discuss_mode": "discuss",
+    "skip_discuss": false,
+    "code_review": true,
+    "code_review_depth": "standard",
+    "code_review_command": null,
+    "pattern_mapper": true,
+    "plan_bounce": false,
+    "plan_bounce_script": null,
+    "plan_bounce_passes": 2,
+    "auto_prune_state": false,
+    "post_planning_gaps": true,
+    "security_enforcement": true,
+    "security_asvs_level": 1,
+    "security_block_on": "high"
+  },
+  "ship": {
+    "pr_body_sections": [
+      {
+        "heading": "User Stories & Acceptance Criteria",
+        "enabled": true,
+        "source": "REQUIREMENTS.md ## User Stories || REQUIREMENTS.md ## Acceptance Criteria",
+        "fallback": "- Acceptance criteria are covered by the linked requirements and verification evidence."
+      },
+      {
+        "heading": "Risks & Dependencies",
+        "enabled": true,
+        "source": "PLAN.md ## Risks || PLAN.md ## Dependencies",
+        "fallback": "- No known high-risk rollout dependencies."
+      },
+      {
+        "heading": "Success Metrics & Release Criteria",
+        "enabled": true,
+        "source": "REQUIREMENTS.md ## Definition of Done || VERIFICATION.md ## Release Criteria",
+        "fallback": "- Release when automated verification and required manual checks pass."
+      },
+      {
+        "heading": "Stakeholder Review & Approval",
+        "enabled": false,
+        "template": "- Product owner approval pending for {phase_name}."
+      }
+    ]
+  },
+  "hooks": {
+    "context_warnings": true
+  },
+  "project_code": null,
+  "phase_naming": "sequential",
+  "agent_skills": {},
+  "claude_md_path": "./CLAUDE.md",
+  "plan_review": {
+    "source_grounding": true,
+    "source_grounding_authority": "grep"
+  },
+  "mode": "yolo",
+  "granularity": "standard"
+}

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -1,0 +1,836 @@
+# Architecture Research
+
+**Domain:** Typed Python CI-Pipe container (Bitbucket Pipelines Pipe, OCI-distributed CLI wrapping `helm` + AWS APIs)
+**Researched:** 2026-06-16
+**Confidence:** HIGH (project structure, auth strategy, test pyramid, multi-arch build — all converge on a single state-of-the-art answer in 2026); MEDIUM (docs site choice — mkdocs-material is recommended but README-only is defensible)
+
+## Standard Architecture
+
+### System Overview
+
+A CI Pipe container is a single-shot CLI. There is no daemon, no request loop. The architecture is a **linear pipeline driven by env vars**, with a small set of orthogonal collaborators behind clean ports.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                     Pipe Entry Point (cli.py)                         │
+│  - parse env vars → typed Settings (pydantic) via PipeAdapter         │
+│  - dispatch to Action handler                                         │
+│  - write success/fail to stdout via bitbucket-pipes-toolkit           │
+└────────┬─────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                       Action Layer (actions/)                         │
+│  ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────┐      │
+│  │  UpgradeAction   │ │   DiffAction     │ │ RollbackAction   │      │
+│  │ (upgrade --inst) │ │ (helm diff up.)  │ │ (helm rollback)  │      │
+│  └────────┬─────────┘ └────────┬─────────┘ └─────────┬────────┘      │
+└───────────┼────────────────────┼───────────────────────┼─────────────┘
+            │                    │                       │
+            ▼                    ▼                       ▼
+┌──────────────────────┐  ┌──────────────────────┐  ┌──────────────────────┐
+│   AuthStrategy       │  │     ChartSource      │  │      HelmClient      │
+│   (Protocol)         │  │     (Protocol)       │  │   (typed wrapper)    │
+│ ┌──────────────────┐ │  │ ┌──────────────────┐ │  │ - upgrade_install()  │
+│ │ StaticKeysAuth   │ │  │ │ LocalPathSource  │ │  │ - diff_upgrade()     │
+│ │ AssumeRoleAuth   │ │  │ │ HelmRepoSource   │ │  │ - rollback()         │
+│ │ OidcWebIdentity  │ │  │ │ OciRegistrySrc   │ │  │ - history()          │
+│ └──────────────────┘ │  │ └──────────────────┘ │  │ (subprocess + JSON)  │
+└──────────┬───────────┘  └──────────┬───────────┘  └──────────┬───────────┘
+           │                          │                         │
+           ▼                          ▼                         ▼
+┌──────────────────────┐   ┌──────────────────────┐   ┌──────────────────────┐
+│   AWS Adapter        │   │   chart fetched      │   │   helm binary        │
+│ (boto3 sessions,     │   │   (path on disk      │   │   (incl. helm-diff   │
+│  EKS describe-cluster│   │   or OCI ref string) │   │   plugin in image)   │
+│  STS, presigned URL  │   └──────────────────────┘   └──────────────────────┘
+│  EKS token gen)      │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  KubeconfigWriter — writes a tempfile kubeconfig from cluster        │
+│  metadata + per-call EKS token; sets KUBECONFIG env for HelmClient   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Key insight: **`HelmClient` never knows how auth works**. It only ever sees a `KUBECONFIG` env var on its subprocess. The `AuthStrategy` produces an `AwsCredentials` object → `AwsAdapter` produces a `ClusterAccess` value object → `KubeconfigWriter` produces a kubeconfig file. The helm path is identical for static keys, `ROLE_ARN`, and OIDC. **Adding a fourth auth strategy = new file, zero changes elsewhere.**
+
+### Component Responsibilities
+
+| Component | Responsibility | Typical Implementation |
+|-----------|----------------|------------------------|
+| `cli` | Entry point. Parse env, dispatch action, emit pipe success/fail. No business logic. | `python -m aws_eks_helm_deploy` |
+| `settings` | Typed, validated env-var schema. Single source of truth for variable names, defaults, coercion. | `pydantic-settings` `BaseSettings` |
+| `pipe_io` | Thin adapter over `bitbucket-pipes-toolkit` (`success`/`fail`/`log_info`). Isolates the toolkit dependency. | Wraps `bitbucket_pipes_toolkit.Pipe` |
+| `actions` | One module per `ACTION`. Orchestrates auth → chart → helm. Knows nothing about subprocess. | `UpgradeAction.run(settings) -> Result` |
+| `auth` | `AuthStrategy` Protocol + concrete strategies. Produces `AwsCredentials`. | `Protocol` + 3 classes |
+| `aws` | Boto3 wrapper. `describe_cluster`, EKS token generation (presigned STS URL → base64). | Pure `boto3`, no `awscli` |
+| `kube` | Renders a kubeconfig file from `ClusterAccess`. Returns a context manager (tempfile cleanup). | Jinja2 template or hand-rolled dict→YAML |
+| `chart` | `ChartSource` Protocol. Resolves `CHART` env (`./path`, `repo://`, `oci://`) to a concrete `ResolvedChart`. | 3 concrete sources |
+| `helm` | Typed wrapper around the `helm` binary. One method per subcommand. Returns parsed results. | `subprocess.run` + stdout parsing |
+| `metadata` | Builds Bitbucket-metadata `--set` injection list. Toggled by `INJECT_BITBUCKET_METADATA`. | Pure function |
+| `errors` | Typed exception hierarchy. Maps internal errors to pipe-friendly exit messages. | Plain `Exception` subclasses |
+| `logging` | Structured logging (`structlog` or stdlib `logging` with JSON formatter). Honours `DEBUG`. | stdlib + JSON renderer |
+
+## Recommended Project Structure
+
+```
+aws-eks-helm-deploy/
+├── pyproject.toml                          # uv-managed; src layout, ruff, mypy, pytest config
+├── uv.lock
+├── README.md
+├── CHANGELOG.md                            # release-please generated
+├── LICENSE                                 # Apache-2.0
+├── pipe.yml                                # Bitbucket Pipes Marketplace manifest
+├── Dockerfile                              # multi-stage, multi-arch
+├── .dockerignore
+│
+├── src/
+│   └── aws_eks_helm_deploy/
+│       ├── __init__.py                     # __version__ (read from package metadata)
+│       ├── __main__.py                     # `python -m aws_eks_helm_deploy` → cli.main()
+│       ├── cli.py                          # entry point: build Settings, dispatch action
+│       ├── settings.py                     # pydantic-settings BaseSettings (env schema)
+│       ├── pipe_io.py                      # bitbucket-pipes-toolkit adapter
+│       ├── errors.py                       # exception hierarchy
+│       ├── logging.py                      # structured logging setup
+│       │
+│       ├── actions/                        # one module per ACTION
+│       │   ├── __init__.py                 # ACTIONS: dict[str, type[Action]]
+│       │   ├── base.py                     # Action ABC / Protocol
+│       │   ├── upgrade.py                  # ACTION=upgrade (default): helm upgrade --install
+│       │   ├── diff.py                     # DRY_RUN=true or ACTION=diff: helm diff upgrade
+│       │   └── rollback.py                 # ACTION=rollback: helm rollback REVISION
+│       │
+│       ├── auth/                           # auth strategy abstraction
+│       │   ├── __init__.py                 # select_strategy(settings) → AuthStrategy
+│       │   ├── base.py                     # AuthStrategy Protocol, AwsCredentials dataclass
+│       │   ├── static_keys.py              # StaticKeysStrategy
+│       │   ├── assume_role.py              # AssumeRoleStrategy (chained on top of static or OIDC)
+│       │   └── oidc.py                     # OidcWebIdentityStrategy (Bitbucket OIDC → STS)
+│       │
+│       ├── aws/                            # pure boto3, no awscli
+│       │   ├── __init__.py
+│       │   ├── session.py                  # build Session from AwsCredentials
+│       │   ├── eks.py                      # describe_cluster, ClusterAccess value object
+│       │   └── eks_token.py                # presigned STS URL → base64 EKS token (replaces awscli internal import)
+│       │
+│       ├── kube/
+│       │   ├── __init__.py
+│       │   └── kubeconfig.py               # write_kubeconfig(cluster_access, token) -> ContextManager[Path]
+│       │
+│       ├── chart/                          # chart source abstraction
+│       │   ├── __init__.py                 # resolve(settings) → ChartSource → ResolvedChart
+│       │   ├── base.py                     # ChartSource Protocol, ResolvedChart dataclass
+│       │   ├── local.py                    # ./relative/path
+│       │   ├── repo.py                     # repo://name/chart with REPO_URL + CHART_VERSION
+│       │   └── oci.py                      # oci://registry/chart with CHART_VERSION
+│       │
+│       ├── helm/
+│       │   ├── __init__.py
+│       │   ├── client.py                   # HelmClient: typed subprocess wrapper
+│       │   ├── args.py                     # ArgBuilder: builds argv from ResolvedChart + values + flags
+│       │   └── exceptions.py               # HelmError, HelmTimeoutError, ChartNotFoundError
+│       │
+│       └── metadata/
+│           ├── __init__.py
+│           └── bitbucket.py                # build --set bitbucket.* from env (if INJECT_BITBUCKET_METADATA)
+│
+├── tests/
+│   ├── conftest.py                         # shared fixtures (fake AWS session, fake helm bin)
+│   ├── unit/                               # pytest, fully mocked, 100% line+branch
+│   │   ├── test_settings.py
+│   │   ├── test_cli.py
+│   │   ├── auth/
+│   │   │   ├── test_static_keys.py
+│   │   │   ├── test_assume_role.py
+│   │   │   └── test_oidc.py
+│   │   ├── aws/
+│   │   │   ├── test_eks.py
+│   │   │   └── test_eks_token.py           # critical: presigned URL must equal awscli's reference output
+│   │   ├── chart/
+│   │   │   ├── test_local.py
+│   │   │   ├── test_repo.py
+│   │   │   └── test_oci.py
+│   │   ├── helm/
+│   │   │   ├── test_args.py
+│   │   │   └── test_client.py              # subprocess mocked
+│   │   ├── actions/
+│   │   │   ├── test_upgrade.py
+│   │   │   ├── test_diff.py
+│   │   │   └── test_rollback.py
+│   │   └── test_metadata.py
+│   │
+│   ├── integration/                        # real helm against kind/k3d, mocked AWS (moto or LocalStack)
+│   │   ├── conftest.py                     # kind cluster lifecycle, helm binary discovery
+│   │   ├── test_upgrade_install.py
+│   │   ├── test_diff_upgrade.py
+│   │   ├── test_rollback.py
+│   │   ├── test_oci_chart.py               # against a local OCI registry container
+│   │   └── test_repo_chart.py
+│   │
+│   └── acceptance/                         # docker build + docker run; exercises real toolkit + entrypoint
+│       ├── conftest.py                     # build image once per session
+│       ├── test_pipe_upgrade.py
+│       ├── test_pipe_dry_run.py
+│       ├── test_pipe_rollback.py
+│       └── fixtures/
+│           ├── helm-stub                   # tiny shell stub replacing /usr/local/bin/helm for hermetic runs
+│           └── charts/                     # minimal test chart
+│
+├── docs/                                   # mkdocs-material site, deployed to GitHub Pages
+│   ├── mkdocs.yml                          # mike-aware versioned docs config
+│   ├── overrides/                          # mkdocs-material partial overrides if needed
+│   ├── index.md
+│   ├── quickstart.md
+│   ├── reference/
+│   │   ├── variables.md                    # generated from settings.py (script in scripts/)
+│   │   ├── actions.md
+│   │   └── auth.md
+│   ├── guides/
+│   │   ├── oidc-setup.md
+│   │   ├── oci-charts.md
+│   │   └── dry-run.md
+│   ├── migration/
+│   │   └── v1-to-v2.md
+│   ├── adr/                                # ADRs (also linked from root README)
+│   │   ├── 0001-github-primary-forge.md
+│   │   ├── 0002-oidc-over-static-keys.md
+│   │   ├── 0003-boto3-only-eks-token.md
+│   │   ├── 0004-cosign-keyless-signing.md
+│   │   ├── 0005-mkdocs-material-versioned.md
+│   │   └── 0006-helm-version-pinning.md
+│   └── v1/                                 # frozen snapshot of v1.x README + variables
+│       └── …
+│
+├── examples/
+│   ├── basic.bitbucket-pipelines.yml
+│   ├── oidc.bitbucket-pipelines.yml
+│   ├── oci-chart.bitbucket-pipelines.yml
+│   ├── multi-env.bitbucket-pipelines.yml
+│   └── dry-run-on-pr.bitbucket-pipelines.yml
+│
+├── scripts/
+│   ├── generate-variables-doc.py           # introspect settings.py → docs/reference/variables.md
+│   └── verify-pipe-yml.py                  # ensure pipe.yml variables ⊆ settings.py
+│
+└── .github/
+    ├── workflows/
+    │   ├── ci.yml                          # lint + type + unit + integration on every PR
+    │   ├── acceptance.yml                  # acceptance tests (Docker image) on PR + main
+    │   ├── release.yml                     # release-please + buildx + cosign + ghcr + dockerhub
+    │   ├── docs.yml                        # mkdocs build + mike deploy to gh-pages
+    │   ├── security.yml                    # trivy + grype + pip-audit on schedule + PR
+    │   └── dependabot-auto-merge.yml
+    ├── dependabot.yml
+    ├── ISSUE_TEMPLATE/
+    │   ├── bug_report.yml
+    │   └── feature_request.yml
+    ├── PULL_REQUEST_TEMPLATE.md
+    └── CODEOWNERS
+```
+
+### Structure Rationale
+
+- **`src/` layout:** Forces the test suite to import the *installed* package, not the working copy. Catches missing `__init__.py`, missing `MANIFEST.in`-style packaging bugs, and import-order quirks before they hit users. Standard in 2026 for any published Python package.
+- **`actions/` as a folder, one module per `ACTION`:** The dispatch table is `ACTIONS = {"upgrade": UpgradeAction, "diff": DiffAction, "rollback": RollbackAction}`. Adding `helm uninstall` later is one new file + one dict entry. The entry point stays five lines.
+- **`auth/`, `chart/` as Protocol-backed packages:** These are the two real polymorphism points. Each has a `base.py` defining the Protocol + value object, and one file per concrete strategy. **You can write a new strategy without touching any other file.**
+- **`aws/` separate from `auth/`:** `auth/` produces `AwsCredentials`; `aws/` *consumes* them to call EKS/STS. This split lets you unit-test EKS token generation against a recorded STS response without dragging the strategy hierarchy into the fixture.
+- **`helm/` isolates the subprocess boundary:** Every other module talks to `HelmClient` via typed methods. Only `helm/client.py` calls `subprocess.run`. Mocking is trivial; replacing the binary with a stub in acceptance tests is trivial.
+- **Three test tiers in separate folders:** `unit/` is the dev-loop tier (millisecond feedback, full mocking, target 100%). `integration/` runs real helm against `kind`/`k3d` with mocked AWS (`moto`) — proves the helm argv builder produces working invocations. `acceptance/` runs the actual Docker image — proves the toolkit contract is honoured. Each tier has its own conftest, its own dependencies, and is selectable via `pytest -m unit` etc.
+- **`docs/` with `mkdocs-material` + `mike`:** Versioned docs are non-negotiable when v1.x users coexist with v2.x users. `mike` is the canonical mkdocs versioning plugin (`mike deploy 2.0`, `mike set-default 2.0`). v1 docs are a frozen snapshot under `docs/v1/`; the README in the repo root points to the docs site and surfaces a short quickstart for marketplace browsers.
+- **`scripts/generate-variables-doc.py`:** The env-var schema is defined exactly once in `settings.py`. The reference docs and the `pipe.yml` `variables:` block are *generated* from it. No more drift between README and `pipe.yml` (which is how the v1 `NAMESPACE` bug happened).
+- **`examples/`:** Marketplace consumers copy-paste from here. Each file is a complete, runnable `bitbucket-pipelines.yml`.
+
+## Architectural Patterns
+
+### Pattern 1: AuthStrategy via `Protocol`
+
+**What:** A single `Protocol` (`AuthStrategy`) with one method `resolve(session_factory) -> AwsCredentials`. Concrete strategies are independent classes; selection is a pure function of `Settings`.
+
+**When to use:** Always — this is the central abstraction that makes the Pipe extensible without touching the helm path.
+
+**Trade-offs:** Slightly more indirection than a chain of `if/elif` in `cli.py`. Worth it because (a) v2.0 has three strategies on day one, (b) mocking is trivial, (c) the next strategy (e.g. EKS Pod Identity for self-hosted runners) is purely additive.
+
+**Example:**
+
+```python
+# src/aws_eks_helm_deploy/auth/base.py
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Protocol
+
+@dataclass(frozen=True, slots=True)
+class AwsCredentials:
+    access_key_id: str
+    secret_access_key: str
+    session_token: str | None
+    region: str
+
+class AuthStrategy(Protocol):
+    def resolve(self) -> AwsCredentials: ...
+
+# src/aws_eks_helm_deploy/auth/__init__.py
+def select_strategy(settings: Settings) -> AuthStrategy:
+    base: AuthStrategy
+    if settings.bitbucket_step_oidc_token:           # OIDC takes precedence
+        base = OidcWebIdentityStrategy(settings)
+    elif settings.aws_access_key_id:
+        base = StaticKeysStrategy(settings)
+    else:
+        raise ConfigurationError("no AWS credentials configured")
+    if settings.role_arn:                            # ROLE_ARN composes on top
+        return AssumeRoleStrategy(base, settings.role_arn)
+    return base
+```
+
+The `AssumeRoleStrategy` *wraps* another `AuthStrategy` — composition, not inheritance. `ROLE_ARN` works with both static keys and OIDC out of the box.
+
+### Pattern 2: Action Dispatch (Command pattern, trivial form)
+
+**What:** `ACTION` env var selects one of `{"upgrade", "diff", "rollback"}`. Each action implements a uniform `run(settings, deps) -> ActionResult` contract. `DRY_RUN=true` is sugar that rewrites `ACTION` to `"diff"` at the CLI layer.
+
+**When to use:** As soon as you have more than one verb. v1 only had upgrade; v2 has three on day one and `uninstall` is a likely v2.1.
+
+**Trade-offs:** vs. a single `do_helm()` function with flags: actions are explicit, testable in isolation, and the success/fail message can be specialised per action.
+
+**Example:**
+
+```python
+# src/aws_eks_helm_deploy/actions/base.py
+class Action(Protocol):
+    name: str
+    def run(self, settings: Settings, deps: Deps) -> ActionResult: ...
+
+# src/aws_eks_helm_deploy/cli.py
+def main(argv: list[str] | None = None) -> int:
+    settings = Settings()  # reads env via pydantic-settings
+    pipe = PipeIO()
+    try:
+        action_name = "diff" if settings.dry_run else settings.action
+        action_cls = ACTIONS[action_name]
+        deps = build_deps(settings)             # wires AuthStrategy, ChartSource, HelmClient
+        result = action_cls().run(settings, deps)
+        pipe.success(result.message)
+        return 0
+    except PipeError as exc:
+        pipe.fail(str(exc))
+        return exc.exit_code
+```
+
+### Pattern 3: ChartSource Protocol
+
+**What:** Mirrors `AuthStrategy`. `ChartSource.resolve() -> ResolvedChart` returns either a local path or an OCI/repo reference string + version. `HelmClient` accepts a `ResolvedChart` and renders the right argv.
+
+**When to use:** From day one — v2 supports `./path`, `repo://name/chart`, and `oci://reg/chart` simultaneously.
+
+**Trade-offs:** A tagged-union with `match` would be terser; the Protocol gives you a place to put the "add helm repo first" side-effect that only the `HelmRepoSource` needs.
+
+```python
+# src/aws_eks_helm_deploy/chart/base.py
+@dataclass(frozen=True, slots=True)
+class ResolvedChart:
+    reference: str          # "./chart" | "oci://…/chart" | "repo-alias/chart"
+    version: str | None     # passed as --version
+    repo_setup: RepoSetup | None  # if not None, run `helm repo add` before upgrade
+
+class ChartSource(Protocol):
+    def resolve(self) -> ResolvedChart: ...
+```
+
+### Pattern 4: Typed `HelmClient` (one method per verb)
+
+**What:** Replace `subprocess.run(["helm", ...])` + `BaseException` with a class whose every public method is named after a helm subcommand and accepts typed parameters. Returns a parsed `HelmResult` (release name, revision, status). Failures raise typed exceptions.
+
+**When to use:** Always — this is the surface that the v1 `BaseException` catch-all hid behind.
+
+**Trade-offs:** More code than `subprocess.run`. But: every helm flag is now a named, type-checked parameter; every error has a typed exception; every method is mockable in unit tests with one `MagicMock`; and the JSON output of `helm` (where available) is parsed into dataclasses, so action code never deals with stdout strings.
+
+```python
+# src/aws_eks_helm_deploy/helm/client.py
+class HelmClient:
+    def __init__(self, binary: str = "helm", env: Mapping[str, str] | None = None) -> None: ...
+
+    def upgrade_install(
+        self,
+        release: str,
+        chart: ResolvedChart,
+        *,
+        namespace: str,
+        create_namespace: bool = False,
+        values_files: Sequence[Path] = (),
+        set_values: Sequence[tuple[str, str]] = (),
+        wait: bool = False,
+        timeout: str = "5m",
+        history_max: int | None = None,
+    ) -> HelmResult: ...
+
+    def diff_upgrade(self, release: str, chart: ResolvedChart, **kwargs: Any) -> DiffResult: ...
+
+    def rollback(self, release: str, revision: int, *, wait: bool = False, timeout: str = "5m") -> HelmResult: ...
+
+    def history(self, release: str, *, max_entries: int = 10) -> list[HistoryEntry]: ...
+```
+
+`actions/upgrade.py`, `actions/diff.py`, `actions/rollback.py` each call exactly one of these methods. **Adding a new action means adding a new method on `HelmClient` and a new file in `actions/`** — same pattern, no surprises.
+
+### Pattern 5: Dependency injection via a `Deps` dataclass
+
+**What:** `cli.py` calls a `build_deps(settings) -> Deps` factory that returns a frozen dataclass holding `auth`, `chart_source`, `helm_client`, `pipe_io`, `clock`. Actions accept `Deps` as a parameter. In tests, `Deps(...)` is constructed with fakes.
+
+**When to use:** Always for testability. This is what makes unit-testing actions trivial without monkeypatching.
+
+**Trade-offs:** Mild boilerplate vs. module-level globals. Worth it 1000×.
+
+## Data Flow
+
+### Invocation Flow (Bitbucket → cluster)
+
+```
+Bitbucket Pipelines runner
+    │   (sets BITBUCKET_*, AWS_*, CLUSTER_NAME, CHART, … in container env)
+    ▼
+docker run yvogl/aws-eks-helm-deploy:2.0
+    │
+    ▼
+ENTRYPOINT: python -m aws_eks_helm_deploy
+    │
+    ▼
+cli.main()
+    │  Settings() — pydantic-settings reads & validates all env vars
+    ▼
+select_strategy(settings) ───────────► AuthStrategy
+    │                                   │ .resolve()
+    │                                   ▼
+    │                                  AwsCredentials  (one of: static / STS-assumed / OIDC-exchanged)
+    │
+    ▼
+build_deps(settings) ───► AwsSession (boto3.Session with creds)
+    │                       │
+    │                       ▼
+    │                     eks.describe_cluster(CLUSTER_NAME)
+    │                       │
+    │                       ▼
+    │                     ClusterAccess(endpoint, ca_data, name, region)
+    │                       │
+    │                       ▼
+    │                     eks_token.generate(cluster_name, session)
+    │                       │  (signs presigned STS GetCallerIdentity URL,
+    │                       │   base64-url encodes with "k8s-aws-v1." prefix)
+    │                       ▼
+    │                     EksAuthToken(value=..., expires_at=...)
+    │                       │
+    │                       ▼
+    │                     kubeconfig.write(ClusterAccess, EksAuthToken)
+    │                       │
+    │                       ▼
+    │                     Path(/tmp/kubeconfig-XXXX)  (context-managed; deleted on exit)
+    │
+    ▼
+chart.resolve(settings) ───► ChartSource ─► ResolvedChart
+    │                                        │
+    │                                        ▼ (if HelmRepoSource) helm repo add NAME URL
+    │
+    ▼
+action = ACTIONS[settings.action or "diff" if dry_run]
+    │
+    ▼
+action.run(settings, deps)
+    │
+    │ UpgradeAction:
+    │     helm_client.upgrade_install(release, chart, namespace=…, …)
+    │ DiffAction:
+    │     helm_client.diff_upgrade(release, chart, …)
+    │ RollbackAction:
+    │     helm_client.rollback(release, revision, …)
+    │
+    ▼
+HelmClient.<method>()
+    │  subprocess.run(["helm", "upgrade", "--install", release, chart.reference,
+    │                  "--namespace", ns, …],
+    │                  env={**os.environ, "KUBECONFIG": str(kubeconfig_path)},
+    │                  check=False, capture_output=True, text=True, timeout=…)
+    │
+    ▼
+HelmResult(release=…, revision=N, status="deployed", stdout=…, stderr=…)
+    │
+    ▼
+pipe.success(f"Deployed release {release} (rev {revision}) to {cluster_name}/{namespace}")
+    │
+    ▼
+exit 0
+```
+
+### Error Flow
+
+```
+Any layer raises PipeError subclass
+    │  - ConfigurationError       (exit 1)  — bad/missing env var
+    │  - AuthenticationError      (exit 2)  — STS/OIDC failed
+    │  - ClusterAccessError       (exit 3)  — describe-cluster failed
+    │  - ChartResolutionError     (exit 4)  — chart not found / version missing
+    │  - HelmError                (exit 5)  — helm exited non-zero (with parsed stderr)
+    │  - HelmTimeoutError         (exit 6)  — wait timed out
+    ▼
+cli.main() catches PipeError
+    ▼
+pipe.fail(error.user_message)   # bitbucket-pipes-toolkit emits styled red output
+    ▼
+exit error.exit_code
+```
+
+Bare `Exception` (anything unexpected) → exit 99 with stack trace in logs, generic message to user.
+
+### State
+
+**There is no persistent state.** The Pipe is a single-shot CLI. The only "state" is:
+- The tempfile kubeconfig (lifetime: one invocation, deleted on exit).
+- Helm's own release history, which lives in the cluster as Secrets — out of our concern.
+
+This is why scaling is a non-issue: every invocation is independent.
+
+## Build Order Implications for v2.0
+
+The dependency graph dictates the phase ordering. **Build the abstractions before the second concrete implementation of each.**
+
+```
+Phase 0: Toolchain bootstrap
+    pyproject.toml + uv + ruff + mypy --strict + pytest skeleton
+    src/ layout with empty __init__.py
+    │
+    ▼
+Phase 1: Settings + PipeIO + errors + logging  (the spine)
+    settings.py (pydantic-settings) covering all v1 vars
+    pipe_io.py wrapping bitbucket-pipes-toolkit
+    errors.py with typed hierarchy
+    logging.py
+    │
+    ▼
+Phase 2: AWS layer — pure boto3 EKS token (kill awscli dependency)
+    aws/session.py, aws/eks.py, aws/eks_token.py
+    Golden test: token matches `aws eks get-token` output byte-for-byte
+    │
+    ▼
+Phase 3: AuthStrategy abstraction + StaticKeys + AssumeRole
+    auth/base.py, auth/static_keys.py, auth/assume_role.py
+    (parity with v1 — no behavioural change yet, just typed)
+    │
+    ▼
+Phase 4: Kube + HelmClient (typed wrapper) + UpgradeAction
+    kube/kubeconfig.py, helm/client.py, helm/args.py
+    actions/upgrade.py — replicates v1 upgrade --install behaviour
+    Integration tests against kind
+    ───────────────────────────────────────────────
+    ★ At this point v2 has v1 parity, fully typed, fully tested ★
+    ───────────────────────────────────────────────
+    │
+    ▼
+Phase 5: OIDC strategy   (additive — auth/oidc.py only)
+    auth/oidc.py — exchanges BITBUCKET_STEP_OIDC_TOKEN at STS
+    Composes with AssumeRoleStrategy for free
+    │
+    ▼
+Phase 6: ChartSource abstraction + LocalPath + HelmRepo + OCI
+    chart/base.py, chart/local.py, chart/repo.py, chart/oci.py
+    HelmClient learns to handle ResolvedChart
+    │
+    ▼
+Phase 7: DiffAction + RollbackAction + HISTORY_MAX
+    actions/diff.py (requires helm-diff plugin in image)
+    actions/rollback.py
+    │
+    ▼
+Phase 8: INJECT_BITBUCKET_METADATA flip (breaking)
+    metadata/bitbucket.py, default=false
+    │
+    ▼
+Phase 9: Multi-arch image + Cosign + SBOM + Trivy in CI
+    Dockerfile multi-stage; buildx amd64+arm64; release.yml
+    │
+    ▼
+Phase 10: Docs site (mkdocs-material + mike) + migration guide + examples
+    Variable reference auto-generated from settings.py
+```
+
+**Critical ordering invariants:**
+1. **Settings before everything.** Every module's signature depends on the typed shape of settings. Getting `Settings` wrong cascades.
+2. **AuthStrategy abstraction (Phase 3) before OIDC (Phase 5).** Build the Protocol with two strategies first; OIDC is then a pure addition. If you build OIDC inline and refactor later, you re-derive the abstraction from one example — bad shape risk.
+3. **HelmClient + UpgradeAction (Phase 4) before DiffAction/RollbackAction (Phase 7).** The wrapper's shape stabilises against the most-used verb first.
+4. **ChartSource (Phase 6) is independent of OIDC (Phase 5).** These two can run in parallel sub-phases if you have the bandwidth — they touch disjoint files.
+5. **Multi-arch image (Phase 9) after the code is feature-complete.** Multi-arch buildx is slow to iterate on; do it once when the source has stopped changing for a moment.
+
+## Docker Image Architecture
+
+### Multi-Stage Multi-Arch Dockerfile
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+ARG PYTHON_VERSION=3.13
+ARG HELM_VERSION=3.16.4
+ARG HELM_DIFF_VERSION=3.10.0
+
+# ── Stage 1: builder ──────────────────────────────────────────────────
+FROM --platform=$BUILDPLATFORM python:${PYTHON_VERSION}-alpine AS builder
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+WORKDIR /build
+COPY pyproject.toml uv.lock README.md ./
+COPY src ./src
+# Resolves and installs into a venv (cross-arch safe — pure Python)
+RUN uv sync --frozen --no-dev --compile-bytecode
+
+# ── Stage 2: helm fetch (per target arch) ─────────────────────────────
+FROM --platform=$TARGETPLATFORM alpine:3.20 AS helm
+ARG HELM_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache curl tar \
+ && curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" \
+    | tar -xz -C /tmp \
+ && mv "/tmp/linux-${TARGETARCH}/helm" /helm \
+ && chmod +x /helm
+
+# ── Stage 3: runtime ──────────────────────────────────────────────────
+FROM --platform=$TARGETPLATFORM python:${PYTHON_VERSION}-alpine AS runtime
+ARG HELM_DIFF_VERSION
+RUN apk add --no-cache git ca-certificates  # git: helm-diff plugin install
+COPY --from=builder /build/.venv /opt/venv
+COPY --from=helm /helm /usr/local/bin/helm
+ENV PATH="/opt/venv/bin:${PATH}" \
+    HELM_PLUGINS=/root/.local/share/helm/plugins \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+RUN helm plugin install https://github.com/databus23/helm-diff --version "v${HELM_DIFF_VERSION}"
+# OCI annotations are added at buildx time via --label / --annotation
+
+ENTRYPOINT ["python", "-m", "aws_eks_helm_deploy"]
+```
+
+### Multi-Arch Build (GitHub Actions)
+
+```yaml
+# .github/workflows/release.yml (excerpt)
+- uses: docker/setup-qemu-action@v3
+- uses: docker/setup-buildx-action@v3
+- uses: docker/build-push-action@v6
+  with:
+    context: .
+    platforms: linux/amd64,linux/arm64
+    push: true
+    provenance: mode=max
+    sbom: true
+    tags: |
+      yvogl/aws-eks-helm-deploy:2.0
+      yvogl/aws-eks-helm-deploy:latest
+      ghcr.io/yves-vogl/aws-eks-helm-deploy:2.0
+      ghcr.io/yves-vogl/aws-eks-helm-deploy:latest
+    annotations: |
+      index:org.opencontainers.image.source=https://github.com/yves-vogl/aws-eks-helm-deploy
+      index:org.opencontainers.image.licenses=Apache-2.0
+      index:org.opencontainers.image.description=Deploy Helm charts to AWS EKS from Bitbucket Pipelines
+- uses: sigstore/cosign-installer@v3
+- run: cosign sign --yes ghcr.io/yves-vogl/aws-eks-helm-deploy@${{ steps.build.outputs.digest }}
+```
+
+**Why this shape:**
+- **`--platform=$BUILDPLATFORM` on the Python builder stage:** Python wheel resolution runs once on the native architecture, not under QEMU emulation. Cuts build time roughly in half on amd64-only CI runners doing arm64 cross-build.
+- **`--platform=$TARGETPLATFORM` on the helm fetch and runtime stages:** these stages contain arch-specific binaries.
+- **Helm fetched in a separate stage:** clean copy, no curl/tar in final image.
+- **`helm-diff` plugin baked in:** required for `DRY_RUN`; installing at runtime would add 5–10s and require network access.
+- **`uv sync --frozen --compile-bytecode`:** lockfile-pinned, pre-compiled `.pyc`, no `pip` in the final image.
+- **`provenance: mode=max` + `sbom: true`:** SLSA build provenance + SPDX SBOM, both attached as OCI attestations. Cosign signs the index, which transitively covers both arches.
+- **OCI annotations on the index (not just the manifests):** so `docker buildx imagetools inspect` shows the metadata.
+
+## Test Strategy
+
+### Test Pyramid
+
+```
+                            ┌─────────────────────┐
+                            │   Acceptance (~10)  │   docker build + docker run
+                            │   GitHub Actions    │   real toolkit, stubbed helm
+                            └─────────────────────┘
+                       ┌──────────────────────────────┐
+                       │      Integration (~30)        │   real helm against kind/k3d
+                       │      GitHub Actions matrix    │   mocked AWS (moto), local OCI registry
+                       └──────────────────────────────┘
+              ┌───────────────────────────────────────────────┐
+              │                Unit (~250)                     │   pytest, full mocking
+              │           pre-commit + every CI run            │   target: 100% line + branch
+              └───────────────────────────────────────────────┘
+```
+
+| Tier | What it proves | Tooling | Where it runs | How long |
+|------|----------------|---------|----------------|----------|
+| Unit | Every module's logic is correct in isolation. Argv builders. EKS token byte-for-byte. Settings validation. Strategy selection. Action orchestration with fake `Deps`. | `pytest`, `pytest-cov` (line+branch, fail-under=100), `pytest-mock`, `freezegun`. AWS mocked at boto3 layer or with `moto`. Helm mocked at `HelmClient` layer. | Locally + GitHub Actions on every PR | <10s |
+| Integration | The helm argv we build actually drives a real helm against a real cluster. OCI charts pull. Repo charts pull. Rollback restores. Diff produces sensible output. | `pytest`, `kind` (or `k3d`), real `helm` binary, `moto` for AWS, ephemeral local OCI registry (`registry:2` container) | GitHub Actions matrix (kind on amd64; arm64 on best-effort) | ~3–5 min |
+| Acceptance | The packaged Docker image, invoked as a real Pipe, honours the toolkit contract: env vars in, success/fail message out, exit code correct. | `pytest`, `docker build`, `docker run`, a shell stub for `helm` mounted at `/usr/local/bin/helm` for hermeticity. Image is built once per pytest session. | GitHub Actions (post-build); the original v1 acceptance tests inside Bitbucket Pipelines also retained as a final sanity check. | ~2 min |
+
+**Boundary discipline:**
+- Unit tests **must not** spawn subprocesses, hit the network, or touch the filesystem outside `tmp_path`.
+- Integration tests **must not** require Docker (kind runs in `dind` on Actions but tests just need `kubectl`/`helm` clients).
+- Acceptance tests **must** build the image — no shortcuts via `python -m aws_eks_helm_deploy` outside the container. They are the only tier that validates `Dockerfile` correctness, `pipe.yml` correctness, and the toolkit wiring.
+
+**Markers (`pyproject.toml`):**
+
+```toml
+[tool.pytest.ini_options]
+markers = [
+  "unit: fast, no I/O, default tier",
+  "integration: requires kind + helm binary",
+  "acceptance: requires docker; builds image",
+]
+addopts = "-m 'unit' --cov=aws_eks_helm_deploy --cov-branch --cov-fail-under=100"
+```
+
+`pytest -m integration` and `pytest -m acceptance` opt into the heavier tiers.
+
+## Documentation Architecture
+
+**Recommendation: `mkdocs-material` + `mike` (versioned), deployed to GitHub Pages.**
+
+- README in the repo root stays short: tagline, badges, quickstart, links to the docs site, marketplace link.
+- `docs/` is the authoritative source.
+- `mike` provides per-version subpaths (`/v1/`, `/v2/`, `/latest/`). Default points to `/v2/`. v1 docs are frozen.
+- **Migration guide (`docs/migration/v1-to-v2.md`)** is the most-visited page on day one — it gets a top-level nav entry and a banner on `/v1/`.
+- **Variable reference is generated** (`scripts/generate-variables-doc.py`) from `settings.py` to guarantee zero drift.
+- ADRs live under `docs/adr/` and are also rendered as a docs-site section.
+
+Why not README-only:
+- Versioning v1 vs v2 docs in a single README is hostile to consumers.
+- The variable reference, examples, ADRs, and migration guide together are far too much for one file.
+- `mkdocs-material` is the de-facto standard in 2026 for Python-project docs; build is fast, search is built in, and GitHub Pages deployment is one workflow step.
+
+## Component Dependency Graph
+
+```
+              ┌──────────────┐
+              │   __main__   │
+              └──────┬───────┘
+                     ▼
+              ┌──────────────┐
+              │     cli      │
+              └──┬──┬───┬─┬──┘
+                 │  │   │ │
+        ┌────────┘  │   │ └────────┐
+        ▼           ▼   ▼          ▼
+   ┌─────────┐ ┌─────────┐ ┌──────────┐ ┌──────────┐
+   │settings │ │ pipe_io │ │  errors  │ │ logging  │
+   └────┬────┘ └─────────┘ └──────────┘ └──────────┘
+        │                       ▲ (raised by everything)
+        │
+        │              ┌────────┴────────────────────────────┐
+        ▼              │                                      │
+   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐ │
+   │ actions  │──▶│   auth   │──▶│   aws    │──▶│   kube   │ │
+   │          │   │ Protocol │   │ (boto3)  │   │  config  │ │
+   └────┬─────┘   └──────────┘   └──────────┘   └─────┬────┘ │
+        │                                              │      │
+        │  ┌──────────┐                                │      │
+        ├─▶│  chart   │                                │      │
+        │  │ Protocol │                                │      │
+        │  └──────────┘                                │      │
+        │                                              │      │
+        ▼                                              ▼      │
+   ┌──────────┐                                  KUBECONFIG=… │
+   │   helm   │◀─────────────────────────────────────────────┘
+   │  client  │
+   └────┬─────┘
+        │ subprocess
+        ▼
+    [helm binary]
+```
+
+Arrows are "imports / depends on". Notice:
+- `auth`, `chart`, `helm` are **siblings** under `actions`. They do not know about each other.
+- `helm` only depends on `errors` (for its exceptions) and reads `KUBECONFIG` from its env. It is auth-agnostic and chart-source-agnostic.
+- Every leaf module is independently testable.
+
+## Anti-Patterns
+
+### Anti-Pattern 1: Threading auth decisions through `HelmClient`
+
+**What people do:** Pass `oidc_token` / `role_arn` into the helm wrapper so it can "set up auth" before calling helm.
+**Why it's wrong:** Every new auth strategy now requires modifying the helm path. The v1 code drifted toward this; it's why adding OIDC was never finished.
+**Do this instead:** Auth produces `AwsCredentials` → AWS layer produces `EksAuthToken` → kube layer writes a kubeconfig → helm sees `KUBECONFIG`. The boundary is `KUBECONFIG`, not credentials.
+
+### Anti-Pattern 2: `subprocess.run` scattered across modules
+
+**What people do:** Call `subprocess.run(["helm", …])` from `pipe.py`, again from `eks/`, again from `actions/`.
+**Why it's wrong:** Mocking requires patching every call site. Error handling diverges. Timeouts are inconsistent.
+**Do this instead:** One `HelmClient` class. One `subprocess.run`. Typed exceptions. The rest of the code never imports `subprocess`.
+
+### Anti-Pattern 3: Catching `BaseException`
+
+**What people do:** v1 does this in several places (and subclasses it for custom errors).
+**Why it's wrong:** Catches `KeyboardInterrupt`, `SystemExit`, `MemoryError`. Hides real failures during tests. PEP 8 explicit no.
+**Do this instead:** Catch `Exception` only. Define a `PipeError(Exception)` root for all custom errors. Let `KeyboardInterrupt` propagate.
+
+### Anti-Pattern 4: Reading env vars in module bodies / function bodies
+
+**What people do:** `os.environ.get("CLUSTER_NAME")` sprinkled across modules.
+**Why it's wrong:** Untestable without monkeypatching `os.environ`. No validation. No type coercion. No central documentation.
+**Do this instead:** All env vars on a single `Settings(BaseSettings)` class. Pass `settings` (or a sliced view) into anything that needs it.
+
+### Anti-Pattern 5: Importing helm/awscli internals
+
+**What people do:** v1 does `from awscli.customizations.eks.get_token import TokenGenerator` — an undocumented internal import that has broken across `awscli` versions.
+**Why it's wrong:** Not a public API. Will break silently.
+**Do this instead:** Implement the ~30 lines of EKS token generation directly with `boto3` + the presigned-URL helper. Cover it with a golden test that compares against `aws eks get-token` output.
+
+### Anti-Pattern 6: Mixing the test pyramid
+
+**What people do:** Put everything under `test/` and rely on naming conventions to skip slow tests.
+**Why it's wrong:** Slow tests leak into the dev loop. Coverage gates can't distinguish "unit branch coverage" from "integration smoke coverage".
+**Do this instead:** Three folders. Three markers. Three CI jobs. Unit is the default; opt in to the others.
+
+### Anti-Pattern 7: Generating `pipe.yml` variables block by hand
+
+**What people do:** Edit `README.md`, `pipe.yml`, and `settings.py` separately.
+**Why it's wrong:** Exactly how v1's `NAMESPACE` default ended up as `kube-public` in README and `default` in `pipe.yml`.
+**Do this instead:** One source of truth (`settings.py`). A `scripts/generate-variables-doc.py` script writes both the docs reference and a `pipe.yml` fragment. CI fails if the generated output differs from what's committed.
+
+## Integration Points
+
+### External Services
+
+| Service | Integration Pattern | Notes |
+|---------|---------------------|-------|
+| AWS STS | `boto3` `client('sts').assume_role` / `assume_role_with_web_identity` | OIDC path uses `BITBUCKET_STEP_OIDC_TOKEN`; do not log the token |
+| AWS EKS | `boto3` `client('eks').describe_cluster` for endpoint+CA; presigned STS URL for token | Token is base64url-encoded `k8s-aws-v1.` prefix; expires in 14 min by default — fine for single-shot Pipe |
+| Bitbucket Pipelines runtime | env vars (`BITBUCKET_*`, `BITBUCKET_STEP_OIDC_TOKEN`) + `bitbucket-pipes-toolkit` for output formatting | Toolkit is the only Bitbucket-specific dep. Wrap it in `pipe_io.py` for testability |
+| Helm registry / OCI | `helm registry login` then `helm pull oci://…` / `helm upgrade oci://…` directly | OCI auth via `REPO_USERNAME` / `REPO_PASSWORD` env vars; do not write to `~/.docker/config.json` permanently |
+| Helm repo (classic) | `helm repo add NAME URL` once at action start; `helm upgrade NAME/CHART --version X` | Repo cache lives in the container; cleared on exit (single-shot) |
+| Kubernetes cluster | `helm` binary uses `KUBECONFIG` env var pointing at our tempfile | We never call `kubectl` — helm has its own Kubernetes client |
+
+### Internal Boundaries
+
+| Boundary | Communication | Notes |
+|----------|---------------|-------|
+| `cli` ↔ `actions` | Function call, `Deps` dataclass passed in | One-way: cli builds deps, action runs |
+| `actions` ↔ `auth` | `auth.select_strategy(settings).resolve()` → `AwsCredentials` | Action does not know about strategies |
+| `actions` ↔ `chart` | `chart.resolve(settings)` → `ResolvedChart` | Action does not know about source types |
+| `actions` ↔ `helm` | `HelmClient.upgrade_install(...)` etc. | Typed args; no string-building outside `helm/args.py` |
+| `aws` ↔ `kube` | `kube.write(cluster_access, token)` → `Path` | Tempfile context-managed; lifetime = invocation |
+| `helm` ↔ `kube` | `KUBECONFIG` env var on subprocess | The only coupling between auth-stack and helm |
+| everything ↔ `errors` | Raise `PipeError` subclasses; `cli` catches | Exit code is a property of the exception class |
+
+## Sources
+
+- The `src/` layout convention: standard Python Packaging Authority guidance, ubiquitous in 2026 Python projects.
+- `pydantic-settings`: official pydantic project for env-var-backed config — replaces ad-hoc `os.environ` parsing.
+- `Protocol` for strategy abstraction: PEP 544, structural subtyping — preferred over ABCs when behaviour is the contract.
+- `mike` for mkdocs versioning: standard plugin for the mkdocs-material ecosystem.
+- `docker buildx` multi-arch + `--platform=$BUILDPLATFORM` cross-compile trick: standard Docker docs pattern for Python images.
+- `cosign` keyless signing with GitHub OIDC + `sigstore` ecosystem: standard supply-chain pattern in 2026.
+- EKS token format (presigned STS GetCallerIdentity URL, base64url, `k8s-aws-v1.` prefix, 15-minute exclusive cluster name header): documented in the `aws-iam-authenticator` repository and the EKS authentication docs.
+- `helm-diff` plugin: `github.com/databus23/helm-diff` — the canonical dry-run plugin in the Helm ecosystem.
+- `kind` and `k3d` for in-CI Kubernetes: standard choices; `kind` slightly more common for GitHub Actions.
+- `moto` for AWS mocking in integration tests: standard `boto3` mocking library.
+
+Confidence is HIGH on every recommendation in this document with the exception of:
+- **mkdocs-material vs README-only:** MEDIUM. README-only is defensible for a small CLI; mkdocs-material wins on versioning support, which is the deciding factor given v1/v2 coexistence.
+- **`kind` vs `k3d`:** MEDIUM. Both work; `kind` is recommended for amd64+arm64 GitHub Actions parity.
+
+---
+*Architecture research for: typed Python CI-Pipe container (Bitbucket Pipelines Pipe for AWS EKS + Helm)*
+*Researched: 2026-06-16*

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -1,0 +1,298 @@
+# Feature Research
+
+**Domain:** Bitbucket Pipelines Pipe — CI-driven Helm deployment to AWS EKS
+**Researched:** 2026-06-16
+**Confidence:** HIGH (well-documented competitor space; conclusions cross-verified across Atlassian Pipes, GitHub Actions, Helmfile/Flux/ArgoCD docs)
+
+> **Scope note.** The v2.0 "must-have" list in `PROJECT.md` (AWS OIDC, OCI/repo charts, dry-run, rollback, `HISTORY_MAX`, opt-in metadata injection) is treated as **already decided** and is not re-recommended here. This document covers what the **competitive ecosystem** ships that we should consider on top, plus features we should deliberately exclude.
+
+---
+
+## Competitive Landscape Surveyed
+
+| Tool | Class | Why it matters here |
+|------|-------|---------------------|
+| `atlassian/aws-eks-kubectl-run` | Bitbucket Pipe | Closest official sibling; sets baseline for Pipe contract conventions |
+| `atlassian/aws-ecs-deploy` | Bitbucket Pipe | Atlassian-blessed pattern for AWS deploys (WAIT, FORCE_NEW_DEPLOYMENT, env var naming) |
+| `atlassian/aws-lambda-deploy` | Bitbucket Pipe | Same — naming and `DEBUG` conventions |
+| `azure/k8s-deploy@v5` | GitHub Action | Most feature-complete equivalent; canary/blue-green strategies, baseline-vs-canary, SMI |
+| `deliverybot/helm` | GitHub Action | Helm-specific GHA, `track` for canary, `task=remove` for cleanup, templated values |
+| `aws-actions/configure-aws-credentials` | GitHub Action | OIDC reference implementation (retry, custom STS endpoint, masked credentials) |
+| `databus23/helm-diff` | Helm plugin | Industry-standard dry-run output, used by Helmfile/Flux |
+| `helmfile/helmfile` | Declarative wrapper | Multi-release manifest, `sync`/`apply`/`diff`/`destroy`, environment values layering |
+| `fluxcd/helm-controller` | GitOps controller | `valuesFrom` (Secret/ConfigMap), `postRenderers`, `dependsOn`, drift detection |
+| `argoproj/argo-cd` | GitOps controller | Renders Helm to manifests + applies; no Helm release ownership |
+| `jkroepke/helm-secrets` | Helm plugin | SOPS-encrypted values files; widely expected by security-conscious teams |
+
+---
+
+## Feature Landscape
+
+### Table Stakes (Users Expect These)
+
+These are features where, if they're missing in v2.0 compared to the broader 2026 CI-deploy ecosystem, the Pipe will feel **unmaintained or toyish** next to GHA/Helmfile alternatives. Items already on the v2.0 must-have list are NOT repeated here.
+
+| # | Feature | Why Expected | Complexity | Depends On |
+|---|---------|--------------|------------|------------|
+| TS-1 | `helm upgrade --atomic` opt-in via `ATOMIC=true` | Default for any production-grade Helm CD pipeline; pairs naturally with `--wait`/`--timeout` which v1 already has. Without it, failed deploys leave half-applied releases. | **S** | — |
+| TS-2 | `--wait-for-jobs` opt-in via `WAIT_FOR_JOBS=true` | Required when chart has `pre-install`/`pre-upgrade` hook jobs (DB migrations). Mentioned in every Helm-in-CI best-practices article 2025-2026. | **S** | `WAIT=true` (already in v1) |
+| TS-3 | `DEBUG=true` variable that toggles `--debug` on Helm and verbose Pipe logging | Atlassian convention across every official Pipe (`aws-ecs-deploy`, `aws-eks-kubectl-run`, `aws-lambda-deploy`). Users will look for it first when something breaks. | **S** | — |
+| TS-4 | Multiple `--values` files (current pipe supports one `VALUES_FILE`; ecosystem expects a list) | Helmfile, Flux, deliverybot/helm, azure/k8s-deploy all support layered values (base + env overrides). Single file forces consumers to pre-merge → friction. | **S** | — |
+| TS-5 | `--set-string` and `--set-file` passthrough via `EXTRA_ARGS` or dedicated `SET_STRING` / `SET_FILE` variables | Standard Helm flags; needed for embedding cert PEMs, long tokens, or numeric-looking values that must stay strings. | **S** | — |
+| TS-6 | Distinct exit codes for: helm failure vs AWS auth failure vs schema/validation failure | Atlassian Pipe convention; lets consumers use Bitbucket "on failure" steps differently per cause. v1 just bubbles whatever Python exception happens. | **M** | exception-hierarchy refactor (already in modernization baseline) |
+| TS-7 | `helm template` pre-flight validation (no cluster needed) when `VALIDATE_ONLY=true` | Cheaper than dry-run, catches schema errors before AWS auth even runs. Helmfile and Flux both do this as a first step. | **S** | — |
+| TS-8 | `helm lint` integration on the chart path before install/upgrade | Industry-standard CI step; every Helm-in-CI tutorial 2025-2026 mentions it. | **S** | — |
+| TS-9 | Credential masking in logs (AWS keys, STS tokens, OIDC tokens, helm-rendered Secrets) | Bitbucket masks declared secrets but `helm get manifest` and `--debug` output happily print rendered Secret manifests. `aws-actions/configure-aws-credentials` masks by default. Failing to do this is a real CVE class. | **M** | — |
+| TS-10 | `KUBECONFIG_OUTPUT_PATH` / explicit kubeconfig artifact path for subsequent pipeline steps | Lets consumers chain a kubectl step after the Pipe without re-authenticating. Pattern used by `aws-actions/configure-aws-credentials` (exposes credentials as outputs). | **S** | — |
+| TS-11 | Helm version pinning displayed in pipe output banner | When the bundled Helm changes (skew policy ADR), users need to immediately see which Helm ran. Helmfile/Flux always log this. | **S** | — |
+| TS-12 | Multiple chart deployment in a single pipe call via `RELEASE` list — **NO**, deliberately deferred to anti-features (see AF-2) | n/a | n/a | n/a |
+| TS-13 | `RELEASE_NAME` validation against DNS-1123 / Helm release-name rules before the call | Helm errors on bad names are cryptic; pre-validating gives a friendly error. Every Helm GHA does this. | **S** | — |
+| TS-14 | Cleanup / uninstall mode (`ACTION=uninstall` with `KEEP_HISTORY=true/false`) | deliverybot/helm has `task=remove`; ephemeral preview-env deployments need this. Without it, consumers write a separate step using a different image. | **S** | rollback subcommand work (action dispatch is being introduced anyway) |
+| TS-15 | Output variables (`BITBUCKET_PIPE_STORAGE_DIR/output`): release name, revision number, status, manifest path | Bitbucket Pipe Toolkit convention; downstream steps (Slack notify, Datadog event) need these. v1 doesn't emit any. | **S** | bitbucket-pipes-toolkit `set_output` (already a dep) |
+| TS-16 | Retry with exponential backoff on STS `AssumeRoleWithWebIdentity` and `eks describe-cluster` | `aws-actions/configure-aws-credentials` retries 12 times by default; AWS APIs throttle in busy accounts. Failure-on-first-throttle looks amateur. | **S** | OIDC work (already in v2.0 scope) |
+| TS-17 | Local kubeconfig path override (`KUBECONFIG_PATH=...`) for advanced users who already have one | Helmfile/Flux/deliverybot all support it. Lets consumers re-use a kubeconfig built by a previous Pipe step. | **S** | — |
+
+**Summary — Table stakes additions: 14 features (TS-1..11, TS-13..17), all S/M complexity, no L items.** Nothing here threatens timeline if done as part of the v2.0 cleanup.
+
+---
+
+### Differentiators (Competitive Advantage)
+
+Features that distinguish this Pipe from the rest of the Bitbucket Pipe field and from Helm-deploy GHAs. Each item is annotated with **v2.0 / v2.1+** scope hint.
+
+| # | Feature | Value Proposition | Complexity | v2.0 or later? |
+|---|---------|-------------------|------------|----------------|
+| D-1 | **Bundled `helm-diff` + automatic Bitbucket PR comment with the diff** when running in a PR pipeline | No competitor Pipe does this. Even Atlassian's own ECS pipe doesn't comment on PRs. Posting `helm diff upgrade` as a Bitbucket PR comment makes this the **only** Pipe that gives reviewers Terraform-style change preview. Massive UX win for the OIDC + PR-preview workflow. | **M** | **v2.0** — `helm-diff` is already bundled for `DRY_RUN`; PR-comment hook via Bitbucket API is incremental |
+| D-2 | **Signed pipe image (Cosign keyless) + SBOM attestation verifiable from consumer pipelines** | No other Bitbucket Pipe in the marketplace ships Cosign-signed images with SBOM as of mid-2026. Consumers can add `cosign verify` to their own pipeline as a supply-chain gate. Story: "the only Pipe you can prove came from this repo." | **M** | **v2.0** — already in distribution-modernization scope; emphasize as a differentiator in marketing |
+| D-3 | **Native Bitbucket Deployments environment integration** — auto-detect `BITBUCKET_DEPLOYMENT_ENVIRONMENT`, surface release/revision to the Deployments dashboard | v1 ignores it. Other Pipes barely use it. Tying Helm release name + revision to Bitbucket's Deployments UI gives consumers free release tracking without a third-party tool. | **M** | **v2.0** — small wrapper; high marketing leverage |
+| D-4 | **`HELM_VALUES_FROM_AWS_SECRETSMANAGER` / `HELM_VALUES_FROM_SSM`** — declarative pull of values from AWS Secrets Manager / SSM Parameter Store as merged values | Flux has `valuesFrom: secret`; no Pipe ecosystem has the equivalent for AWS-native secret stores. Since we already authenticate to AWS, fetching values from Secrets Manager is a 30-line addition that solves the "I don't want to commit even encrypted secrets" use case **without** asking users to install SOPS. | **M** | **v2.1** — defer to after v2.0 launches; needs an ADR on schema (which path, which format) |
+| D-5 | **`POST_RENDERER=kustomize`** — bundled `kustomize` binary + automatic `helm template \| kustomize build -` post-rendering | Flux supports this; no Bitbucket Pipe does. The "I love Helm but need to patch one label on one object" use case is universal and currently forces users off the Pipe. | **M** | **v2.1** — adds image size; needs careful UX design |
+| D-6 | **Schema-validated input variables with rich error messages** — `pipe.yml` ships JSON Schema; pre-flight validates user inputs and prints "did you mean `CLUSTER_NAME` not `EKS_CLUSTER`?" before any AWS call | bitbucket-pipes-toolkit supports schema; few Pipes use it well. Combined with our `mypy --strict` + `ruff` story, this is a "this Pipe is built right" signal. | **S** | **v2.0** — leverages existing `pipe/schema.py` |
+| D-7 | **Cold-start under 10 s** (current v1.3.0: full `awscli` + Python startup ≈ 25-40 s) — `boto3`-only + lazy imports + Alpine + `helm` precompiled | This is invisible until you ship 100 deploys/day. Competitors don't advertise it because most are 30 s+. "Fastest EKS-Helm Pipe on the Bitbucket Marketplace" is a defensible claim. | **M** | **v2.0** — already implied by "drop awscli" decision; just needs to be benchmarked and publicized |
+| D-8 | **First-class IRSA support** (when the consumer mounts a service-account token; for pipes-on-self-hosted-runner cases) | Bitbucket self-hosted runners can run on EKS with IRSA. Supporting `AWS_WEB_IDENTITY_TOKEN_FILE` natively (the var `aws-actions/configure-aws-credentials` already uses) gives self-hosted runners a zero-config path. | **S** | **v2.0** — `boto3` already reads `AWS_WEB_IDENTITY_TOKEN_FILE`; just don't break it |
+| D-9 | **`--show-only`-style filter for dry-run output** — let users render only specific templates in the diff for very large charts | Helm has `helm template --show-only`; CI tools rarely expose it. Reduces noise in PR comments to "show only the Deployment, not the 47 ConfigMaps." | **S** | **v2.1** |
+| D-10 | **Status-summary output as machine-parsable JSON** to `BITBUCKET_PIPE_STORAGE_DIR/output.json` | No Bitbucket Pipe does this well. Enables consumers to write generic "post a deploy event to Datadog/Honeycomb" steps without parsing log output. | **S** | **v2.0** — pairs with TS-15 |
+
+**Differentiator count not appearing in competitor Pipes (the gate requires ≥3):**
+1. **D-1** — PR-comment helm-diff: no competing Pipe does this.
+2. **D-2** — Cosign + SBOM signed Pipe image: no competing Pipe ships this.
+3. **D-3** — Bitbucket Deployments dashboard integration: under-used by all competing Pipes.
+4. **D-4** — Values-from-AWS-Secrets-Manager: not in any Pipe or major GHA.
+5. **D-7** — Sub-10 s cold start with benchmark: no Pipe publishes this metric.
+
+Five differentiators clear the gate. **D-1, D-2, D-3, D-7 are all in v2.0 scope.** D-4 and D-5 are deliberately deferred to v2.1.
+
+---
+
+### Anti-Features (Deliberately NOT Built)
+
+Features that surface in user requests or competitor matrices but would break the Pipe's value proposition.
+
+| # | Feature | Why Tempting | Why Problematic | Better Approach |
+|---|---------|--------------|-----------------|-----------------|
+| AF-1 | **Continuous reconciliation / drift detection** (à la Flux Helm Controller, ArgoCD auto-sync) | "Why not give the Pipe a `RECONCILE=true` mode?" | A Pipe is a **one-shot CI step**; reconciliation requires a long-running in-cluster controller. Re-running the Pipe on a cron doesn't fix drift between runs; it just *pretends* to. Building this would mean owning a controller — out of scope, and Flux/ArgoCD already win this space. | Document in README: "If you need drift detection, install Flux Helm Controller and use this Pipe only for bootstrapping." |
+| AF-2 | **Multi-release / declarative manifest** (`releases:` list à la Helmfile) | Users with 10 releases want one Pipe call to deploy them all. | Helmfile already does this perfectly and is OSS. Re-implementing it inside a Pipe duplicates a battle-tested tool **and** breaks the "one Pipe call = one observable deployment" Bitbucket Deployments model. | Document: "For multi-release orchestration, call this Pipe once per release in a Bitbucket pipeline `parallel:` block, or use Helmfile." |
+| AF-3 | **Templated/scaffolded chart generation** (deliverybot/helm's "app" built-in chart) | "Why not bundle a generic chart so users don't need their own?" | Users always need to customize. A bundled chart becomes a forever-maintenance burden (every new K8s API version breaks it) and is wrong for 95% of consumers. | Point users at `helm create` + Bitnami common charts. Provide one `examples/` chart that's clearly labelled "example only, not a product." |
+| AF-4 | **Canary / blue-green strategy orchestration** (à la `azure/k8s-deploy` strategy=canary with baseline/-canary suffix workloads) | "If we have rollback, why not also canary?" | Canary requires either a service mesh (Istio/Linkerd SMI) or chart-level rolling-update semantics. Building generic canary logic into a Helm wrapper means *rewriting* Argo Rollouts / Flagger inside the Pipe. Wrong layer. | Document: "Use Argo Rollouts or Flagger as the chart's deployment kind; this Pipe handles the Helm release lifecycle around it." |
+| AF-5 | **Managing Helm repos as long-lived state** (`helm repo add` persisted across runs, repo cache mounted as volume) | "Performance — why re-add the repo every run?" | Each Pipe invocation is ephemeral. Persisting repo state requires consumer-side cache volumes (which Bitbucket Pipes doesn't standardize) and creates a class of cache-corruption bugs. | Always `helm repo add --force-update` per run. Document trade-off. The cold-start budget (D-7) already accounts for this. |
+| AF-6 | **Bitbucket-only secret manager wrapper** (a "fetch secret from Bitbucket repo variable and inject as Helm value" feature) | Looks convenient. | Bitbucket repo variables are *already* env vars when the Pipe runs. Wrapping that with a custom syntax invents a non-standard mechanism — violates the NIH rule. | Document the existing `helm --set $MY_SECRET` pattern. |
+| AF-7 | **Bundled `kubectl`** (so the Pipe can also do `kubectl apply` post-deploy hooks) | "I want to label a node after deploy." | Scope creep. The Pipe is for Helm. `atlassian/aws-eks-kubectl-run` exists for kubectl. Bundling kubectl bloats the image and blurs the boundary. | Document: "Chain this Pipe with `atlassian/aws-eks-kubectl-run` for kubectl operations." |
+| AF-8 | **Slack/Teams/email notifications** baked in | "Tell me when deploys fail." | Notification is a cross-cutting concern; every team uses a different tool. Building it in means maintaining 5+ integrations forever. | Emit structured output (D-10, TS-15) so the consumer chains their own notification Pipe (Atlassian ships `slack-notify`). |
+| AF-9 | **Storing release state in S3/DynamoDB** (Terraform-style remote backend for Helm) | "What if the cluster is gone?" | Helm release state already lives in cluster Secrets (Helm 3). Adding a parallel external store creates split-brain. If the cluster is gone, the release is gone — that's the right semantics. | Use `helm get values <release> -o yaml` in a pre-Pipe step to back up state if needed. Document. |
+
+**Anti-feature count (gate requires ≥3): 9 documented, each with reasoning.** ✓
+
+---
+
+## Feature Dependencies
+
+```
+TS-1 (--atomic) ──pairs──> TS-2 (--wait-for-jobs)
+         └──recommends──> v2.0 rollback (already in scope)
+
+TS-6 (typed exit codes) ──requires──> exception-hierarchy refactor (modernization baseline)
+
+TS-7 (helm template validate) ──enhances──> TS-8 (helm lint)
+                                └──enhances──> v2.0 DRY_RUN (already in scope)
+
+TS-9 (log masking) ──blocks──> TS-15 (output emission)
+         └──blocks──> D-1 (PR-comment helm-diff)
+        [must redact rendered Secret manifests before any external posting]
+
+TS-15 (set_output) ──requires──> D-10 (JSON output)
+
+TS-16 (STS retry) ──requires──> v2.0 OIDC (already in scope)
+
+D-1 (PR helm-diff) ──requires──> v2.0 helm-diff bundling (already in scope)
+       └──requires──> Bitbucket API token surface (new) ──conflicts──> "no extra secrets" UX promise
+                                                          └──mitigation──> use BITBUCKET_TOKEN
+                                                                          (auto-provided in pipelines)
+
+D-3 (Deployments dashboard) ──requires──> TS-15 (output emission)
+
+D-4 (Secrets Manager values) ──requires──> v2.0 OIDC (already in scope)
+                              └──conflicts──> AF-6 (custom secret wrapper) — D-4 is the
+                                              standards-aligned alternative
+
+D-7 (cold-start <10s) ──requires──> v2.0 "drop awscli" decision (already in scope)
+                       └──requires──> benchmark harness (new — small, but must exist)
+
+D-8 (IRSA) ──compatible-with──> v2.0 OIDC (different code path; both can coexist)
+
+AF-2 (multi-release) ──conflicts──> Bitbucket Deployments single-deployment model
+                                    (so we deliberately don't ship it)
+```
+
+### Dependency Notes
+
+- **Critical:** TS-9 (log masking) is a **blocker** for D-1 and TS-15. Posting helm-diff output as a PR comment or writing it to an output file without redacting `kind: Secret` blocks is a credential-leak vector. **Must be in v2.0 before D-1 ships.**
+- **Critical:** D-1 (PR comment) needs the Bitbucket API. The Bitbucket Pipes environment auto-provides `BITBUCKET_TOKEN` for repo write-access, so this does **not** require asking the consumer to configure a new secret.
+- **Easy win cluster:** TS-1, TS-2, TS-3, TS-13, D-6 can all be done in a single PR — all are `pipe.yml` schema additions + thin Helm flag plumbing.
+- **Defer cleanly:** D-4 (`HELM_VALUES_FROM_AWS_SECRETSMANAGER`) and D-5 (post-renderer/kustomize) are excellent v2.1 features. They don't unlock v2.0 and they each warrant their own ADR.
+
+---
+
+## MVP Definition
+
+### v2.0 Launch — Table-stakes work
+
+All TS items except TS-12 (deliberately excluded) and TS-14 (uninstall — can be cut if timeline pressures):
+
+- [x] *Already locked in PROJECT.md:* OIDC, OCI/repo charts, dry-run, rollback, `HISTORY_MAX`, opt-in metadata
+- [ ] **TS-1** `ATOMIC` variable
+- [ ] **TS-2** `WAIT_FOR_JOBS` variable
+- [ ] **TS-3** `DEBUG` variable (Atlassian convention)
+- [ ] **TS-4** multiple `VALUES_FILE` (list, not scalar)
+- [ ] **TS-5** `SET_STRING` / `SET_FILE` variables
+- [ ] **TS-6** typed exit codes (depends on exception-hierarchy refactor, which is already in baseline)
+- [ ] **TS-7** `VALIDATE_ONLY=true` (`helm template`-only path)
+- [ ] **TS-8** `helm lint` integrated into validate/dry-run paths
+- [ ] **TS-9** log masking (rendered Secrets + AWS tokens) — **security blocker for D-1**
+- [ ] **TS-10** `KUBECONFIG_OUTPUT_PATH`
+- [ ] **TS-11** Helm-version banner in pipe output
+- [ ] **TS-13** release-name DNS-1123 validation
+- [ ] **TS-14** `ACTION=uninstall` (can defer to v2.0.1 if needed)
+- [ ] **TS-15** `set_output` for `release`, `revision`, `status`, `manifest_path`
+- [ ] **TS-16** STS retry with backoff
+- [ ] **TS-17** `KUBECONFIG_PATH` override
+
+### v2.0 Launch — Differentiators
+
+- [ ] **D-1** helm-diff posted as Bitbucket PR comment when running in a PR pipeline
+- [ ] **D-2** Cosign-signed image + SBOM attestation (already in PROJECT scope; emphasize in README)
+- [ ] **D-3** Bitbucket Deployments dashboard integration
+- [ ] **D-6** Rich pipe.yml JSON Schema with friendly error messages
+- [ ] **D-7** Cold-start benchmark + sub-10s guarantee
+- [ ] **D-8** IRSA via `AWS_WEB_IDENTITY_TOKEN_FILE`
+- [ ] **D-10** JSON output blob
+
+### v2.1+ — After v2.0 stabilizes
+
+- [ ] **D-4** `HELM_VALUES_FROM_AWS_SECRETSMANAGER` / `HELM_VALUES_FROM_SSM`
+- [ ] **D-5** Kustomize post-renderer
+- [ ] **D-9** `--show-only` filtering for dry-run
+
+### Explicit non-goals — never ship
+
+See Anti-Features table; AF-1 through AF-9.
+
+---
+
+## Feature Prioritization Matrix
+
+| Feature | User Value | Implementation Cost | Priority |
+|---------|-----------|---------------------|----------|
+| TS-1 ATOMIC | HIGH | LOW | **P1** |
+| TS-2 WAIT_FOR_JOBS | HIGH | LOW | **P1** |
+| TS-3 DEBUG | HIGH | LOW | **P1** |
+| TS-4 multi-values | HIGH | LOW | **P1** |
+| TS-5 SET_STRING/SET_FILE | MEDIUM | LOW | **P1** |
+| TS-6 typed exit codes | MEDIUM | MEDIUM | **P1** (paired with baseline refactor) |
+| TS-7 VALIDATE_ONLY | MEDIUM | LOW | **P1** |
+| TS-8 helm lint | MEDIUM | LOW | **P2** (nice to have, not gating) |
+| TS-9 log masking | HIGH (security) | MEDIUM | **P1** (blocker for D-1) |
+| TS-10 KUBECONFIG_OUTPUT_PATH | MEDIUM | LOW | **P2** |
+| TS-11 Helm version banner | LOW | LOW | **P1** (trivial, ships with banner work) |
+| TS-13 release-name validation | MEDIUM | LOW | **P1** |
+| TS-14 uninstall | MEDIUM | LOW | **P2** (defer to v2.0.1 if needed) |
+| TS-15 set_output | HIGH | LOW | **P1** |
+| TS-16 STS retry | HIGH | LOW | **P1** (security/reliability) |
+| TS-17 KUBECONFIG_PATH | LOW | LOW | **P2** |
+| D-1 PR helm-diff comment | HIGH | MEDIUM | **P1** (signature feature) |
+| D-2 Cosign + SBOM | HIGH | MEDIUM | **P1** (already in scope) |
+| D-3 Deployments dashboard | HIGH | MEDIUM | **P1** |
+| D-6 schema-driven errors | MEDIUM | LOW | **P1** |
+| D-7 cold-start <10s | MEDIUM | MEDIUM | **P1** (already implied by awscli drop) |
+| D-8 IRSA | MEDIUM | LOW | **P1** (free with boto3 path) |
+| D-10 JSON output | MEDIUM | LOW | **P1** (pairs with TS-15) |
+| D-4 Secrets Manager values | HIGH | MEDIUM | **P2** (v2.1) |
+| D-5 Kustomize post-renderer | MEDIUM | MEDIUM | **P3** (v2.1) |
+| D-9 --show-only filter | LOW | LOW | **P3** (v2.1) |
+
+**Priority key:**
+- **P1**: v2.0 launch blocker
+- **P2**: v2.0 if time permits, else v2.0.x
+- **P3**: v2.1+
+
+---
+
+## Competitor Feature Analysis
+
+| Feature | `atlassian/aws-eks-kubectl-run` | `azure/k8s-deploy` | `deliverybot/helm` | Helmfile / Flux | **Our Approach** |
+|---|---|---|---|---|---|
+| OIDC auth | No (static keys only) | Pairs with `azure/login` | No (kubeconfig file) | n/a (in-cluster) | **First-class, with static fallback (v2.0)** |
+| Helm-diff / dry-run | No (kubectl-only) | No (kubectl-based) | No | Yes (Helmfile `diff`, Flux events) | **Yes + PR comment (D-1)** |
+| Rollback | Manual via kubectl | Yes (canary reject) | No | Yes (`helm rollback`) | **Yes, dedicated `ACTION=rollback` (v2.0)** |
+| OCI charts | n/a | Yes | Partial | Yes | **Yes (v2.0)** |
+| Multi-values file | n/a | n/a | Yes | Yes | **Yes (TS-4)** |
+| Canary strategy | No | Yes | Yes (`track`) | Yes (Flagger/Rollouts) | **No — AF-4** |
+| Multi-release | No | No | No | Yes | **No — AF-2** |
+| Image signing (Cosign) | No | No | No | n/a (the tool itself) | **Yes (D-2)** |
+| Bundled `helm-diff` | n/a | n/a | No | Yes (Helmfile) | **Yes (v2.0)** |
+| Bundled `kustomize` | No | Yes (manifest mode) | No | Yes (post-renderer) | **Deferred to v2.1 (D-5)** |
+| Drift detection | No | No | No | Yes (Flux) | **No — AF-1** |
+| Secret-store values | No | No | No | Yes (Flux `valuesFrom`) | **Yes for AWS-native, v2.1 (D-4)** |
+| Bitbucket Deployments | No | n/a | n/a | n/a | **Yes (D-3)** |
+| Output variables | Partial | Yes | Partial | n/a | **Yes, structured JSON (D-10)** |
+| PR diff comment | No | No | No | Manual scripting | **Yes — signature feature (D-1)** |
+
+---
+
+## Most Surprising Findings (for the summary)
+
+1. **No Bitbucket Pipe in the marketplace ships a Cosign-signed image with SBOM as of mid-2026.** D-2 is a credible "best-in-class supply-chain" claim with very little extra work beyond what's already in scope.
+2. **Atlassian's own EKS Pipe (`aws-eks-kubectl-run`) has no OIDC support and no Helm support** — the gap our v2.0 fills is wider than the issue tracker suggested.
+3. **Posting helm-diff as a Bitbucket PR comment (D-1) is genuinely novel** in the Pipe ecosystem and trivially achievable because Bitbucket Pipelines auto-provides `BITBUCKET_TOKEN`. No consumer setup, big "wow" demo.
+4. **The "drop full `awscli`" decision in PROJECT.md is also the biggest marketing lever**: a documented sub-10s cold-start beats every competitor Pipe and most GHAs. Worth a benchmark in the README.
+5. **TS-9 log masking is a non-obvious security blocker** — `helm get manifest` and `helm template --debug` both print rendered `Secret` manifests in plaintext. Any feature that exposes that output (D-1 PR comments, D-10 JSON output) is a credential-leak vector until we redact. **Must land first.**
+6. **GitOps reconciliation (Flux/ArgoCD) and Helmfile's multi-release model are not gaps — they are wins.** They define what our Pipe deliberately does **not** do, freeing us to be the best-in-class **one-shot CI Pipe** rather than a worse imitation of either.
+
+---
+
+## Sources
+
+- [atlassian/aws-eks-kubectl-run (Bitbucket)](https://bitbucket.org/atlassian/aws-eks-kubectl-run)
+- [Deploy to AWS EKS — Bitbucket Cloud docs (Atlassian Support)](https://support.atlassian.com/bitbucket-cloud/docs/deploy-to-aws-eks-kubernetes/)
+- [Deploy on AWS using Bitbucket Pipelines OpenID Connect (Atlassian Support)](https://support.atlassian.com/bitbucket-cloud/docs/deploy-on-aws-using-bitbucket-pipelines-openid-connect/)
+- [Azure/k8s-deploy GitHub Action README](https://github.com/Azure/k8s-deploy/blob/main/README.md)
+- [Azure/k8s-deploy Marketplace listing](https://github.com/marketplace/actions/deploy-to-kubernetes-cluster)
+- [deliverybot/helm GitHub Action](https://github.com/deliverybot/helm)
+- [Deliverybot Helm Action Marketplace](https://github.com/marketplace/actions/deliverybot-helm-action)
+- [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)
+- [databus23/helm-diff](https://github.com/databus23/helm-diff)
+- [Flux helm-controller HelmRelease spec](https://github.com/fluxcd/helm-controller/blob/main/docs/spec/v2beta1/helmreleases.md)
+- [Flux Manage Helm Releases](https://fluxcd.io/flux/guides/helmreleases/)
+- [Flux CD vs ArgoCD: Helm Support Comparison (OneUptime, 2026-03)](https://oneuptime.com/blog/post/2026-03-06-flux-cd-vs-argocd-helm-support-comparison/view)
+- [Helm upgrade docs (helm.sh)](https://helm.sh/docs/helm/helm_upgrade/)
+- [Helm Performance Optimization (OneUptime, 2026-01)](https://oneuptime.com/blog/post/2026-01-17-helm-performance-optimization-large-scale/view)
+- [How to Upgrade and Rollback Helm Releases Safely (OneUptime, 2026-01)](https://oneuptime.com/blog/post/2026-01-17-helm-upgrade-rollback-releases/view)
+- [Helm Diff plugin: Preview Changes (OneUptime, 2026-02)](https://oneuptime.com/blog/post/2026-02-09-helm-diff-plugin-preview-changes/view)
+- [helm-secrets (jkroepke) Usage wiki](https://github.com/jkroepke/helm-secrets/wiki/Usage)
+- [Helm Secrets: Secure Kubernetes Secrets Management Guide (GitGuardian)](https://blog.gitguardian.com/how-to-handle-secrets-in-helm/)
+- [HelmRelease ValuesFrom Secret in Flux (OneUptime, 2026-03)](https://oneuptime.com/blog/post/2026-03-05-helmrelease-valuesfrom-secret-flux/view)
+- [Detect Helm Drift with Flux CD (OneUptime, 2026-03)](https://oneuptime.com/blog/post/2026-03-05-detect-helm-drift-flux-cd/view)
+- [Argo CD anti-patterns (Codefresh)](https://codefresh.io/blog/argo-cd-anti-patterns-for-gitops/)
+
+---
+*Feature research for: Bitbucket Pipelines Pipe — CI-driven Helm deployment to AWS EKS*
+*Researched: 2026-06-16*

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -1,0 +1,301 @@
+# Pitfalls Research
+
+**Domain:** Bitbucket Pipelines Pipe — Helm-to-EKS deployment with AWS OIDC, OCI charts, Cosign signing, multi-arch images, and GitHub-Actions release pipeline (v1→v2 modernization of an existing public Pipe)
+**Researched:** 2026-06-16
+**Confidence:** HIGH (drawn from current upstream docs, known issue trackers, and lived patterns; AWS STS now validates IdP claims as of 2026-01)
+
+Pitfalls below are scoped to **this** modernization. Severity is judged against the v2 Core Value promise: "ship a Bitbucket Pipelines deployment to AWS EKS from a clean repository in under five minutes — without committing static AWS credentials and without surprises at upgrade time." Anything that breaks that promise — or breaks an existing v1.x pinned consumer's understanding of how to upgrade — is critical.
+
+## Critical Pitfalls
+
+### Pitfall 1: Bitbucket OIDC `aud` claim mismatch and STS trust policy under-constrained
+
+**What goes wrong:**
+The Bitbucket OIDC token (`BITBUCKET_STEP_OIDC_TOKEN`) is exchanged for AWS credentials via `sts:AssumeRoleWithWebIdentity`. If the IAM OIDC provider's `ClientIDList` does not contain the exact Bitbucket audience (`api.bitbucket.org/2.0/workspaces/{WORKSPACE}/pipelines-config/identity/oidc`) or if the IAM role trust policy does not constrain `token.actions.bitbucket.org:sub` to a specific repository / step / branch, the pipe either (a) fails opaquely with `InvalidIdentityToken: Incorrect token audience` (Core Value broken: "under five minutes" turns into a half-day STS-debugging detour), or (b) succeeds and silently allows **any** Bitbucket workspace to assume the role — a privilege-escalation hand-grenade for consumers.
+
+The pitfall is worse for this pipe specifically because we publish it as a **shared component** used by external workspaces — every consumer copy-pastes the trust policy from our docs, so a sloppy default propagates 9+ times.
+
+**Why it happens:**
+- AWS STS uses the `azp` (authorized party) claim as the audience when both `aud` and `azp` are present — but Bitbucket only emits `aud`, so people don't notice this gotcha until they switch providers.
+- Multiple audiences in one JWT are not supported by AWS STS at all.
+- The Atlassian docs show a permissive trust policy (`StringLike: "*"`) as an "intro" example, and people ship that to production.
+- v1.x had no OIDC at all, so there is no existing user mental model to fall back on — we are setting the precedent.
+
+**How to avoid:**
+- Document **exactly one** trust-policy template that pins all three: `aud` (Bitbucket workspace audience URL), `sub` (`{workspace_uuid}:{repo_uuid}:{step_uuid}` or at minimum repo-scoped), and optionally a branch condition.
+- Ship a `examples/oidc-trust-policy.json` with placeholder UUIDs and **no wildcards**.
+- In the pipe, validate the token shape before calling STS: assert `aud` is non-empty and is a single string (not a list). Fail with an actionable error: `OIDC token aud is "X" — verify your AWS IAM OIDC provider's ClientIDList contains exactly this string`.
+- Surface the AWS error verbatim in the pipe output (do not swallow `InvalidIdentityToken`) but prefix with a remediation hint pointing at the docs URL.
+- Test against AWS STS's January 2026 IdP-claim validation feature — confirm our claim shape passes the new path.
+
+**Warning signs:**
+- Anyone in a code review proposing `"Condition": { "StringLike": { "...:sub": "*" } }` — instant block.
+- Consumer issues with `InvalidIdentityToken` filed in the first week post-release.
+- Trust-policy examples in the docs that contain `"*"` anywhere except as an explicit placeholder marker like `<WORKSPACE_UUID>`.
+
+**Phase to address:**
+Phase: **AWS OIDC / IRSA implementation**. This is the highest-blast-radius pitfall in v2 because it is both a security primitive and a documentation deliverable, and the docs ship to consumers we do not control.
+
+---
+
+### Pitfall 2: `INJECT_BITBUCKET_METADATA` default flip silently breaks existing pinned consumers who upgrade
+
+**What goes wrong:**
+v1.x unconditionally injects Bitbucket metadata as Helm values (`bitbucket.bitbucket_build_number`, etc.). v2 flips this to opt-in (`INJECT_BITBUCKET_METADATA: false` default — see issue #16). Any consumer who:
+1. Has a Helm chart with a values schema (`values.schema.json`) that **requires** these fields, OR
+2. References `.Values.bitbucket.bitbucket_build_number` in a template,
+
+will experience a **silent template failure or `nil` deref** on first run of v2. The pipe exits non-zero with a Helm error, but the root cause ("v2 stopped injecting metadata you depended on") is invisible — Helm just says "field bitbucket not found in values".
+
+This is the migration-pitfall most likely to generate angry GitHub issues in the first 48 hours.
+
+**Why it happens:**
+- v1.x users built mental models around "this just happens" for three years.
+- Changelogs and migration guides are skimmed; defaults are not.
+- The v1→v2 image lives on a new tag (`:2.0.0`) but consumers who use `:latest` (we cannot stop them) get the change without reading anything.
+
+**How to avoid:**
+- The pipe must **detect** the upgrade scenario: if no `INJECT_BITBUCKET_METADATA` is set explicitly AND we can detect that the chart's existing values (from `helm get values <release>`) contain a `bitbucket.*` key, emit a **prominent warning** before deploying: `WARNING: v1.x injected Bitbucket metadata by default; v2 does not. Set INJECT_BITBUCKET_METADATA: true to preserve v1 behavior. This deploy will proceed WITHOUT metadata.`
+- Do **not** auto-fallback to v1 behavior — that defeats the breaking change. Just make the silence audible.
+- Pin `:latest` to v1.3.0 forever (do not move it to v2). Document this in the README upgrade section. v2 consumers must opt in with `:2`, `:2.0`, or `:2.0.0`.
+- Migration guide must list `INJECT_BITBUCKET_METADATA` in the **first** "Breaking Changes" table row with a concrete `bitbucket-pipelines.yml` before/after diff.
+- Acceptance test: invoke the pipe with no env vars and assert the warning fires when a prior release contained `bitbucket.*` keys.
+
+**Warning signs:**
+- Migration guide draft that lists the change but does not show a diff.
+- No release-note assertion in the test suite.
+- Any code path that defaults `INJECT_BITBUCKET_METADATA` to `true` "for compatibility" — instant block; defeats the entire feature.
+
+**Phase to address:**
+Phase: **Opt-in Bitbucket metadata injection (issue #16)** plus **Migration guide v1→v2**. Cross-cutting; both phases must explicitly reference this pitfall in their done criteria.
+
+---
+
+### Pitfall 3: Helm `--atomic` + `--wait` rollback breaks when previous release did not also use `--wait`
+
+**What goes wrong:**
+v1.x exposes `--wait` and `--timeout` as optional. If a consumer runs revision N **without** `--wait`, and revision N+1 **with** `--atomic`, Helm's auto-rollback target (revision N) is itself in a state Helm believes is "deployed" but Kubernetes never actually converged. The rollback then either (a) completes instantly to a still-broken state (worst case — production traffic on a half-deployed release), or (b) fails with `another operation (install/upgrade/rollback) is in progress` and leaves the release locked.
+
+`--history-max` (issue #17) compounds this: if the consumer sets `HISTORY_MAX: 3` and has been deploying nightly, the only `--wait`-clean revision available for rollback may have already been pruned. Rollback then targets a dirty revision and silently degrades.
+
+**Why it happens:**
+- `--atomic` implies `--wait` only for the **current** upgrade, not retroactively for the history.
+- Helm's "deployed" status reflects the last `helm upgrade` exit, not actual Kubernetes reconciliation.
+- `--cleanup-on-fail` is off by default; partial resources from a failed install remain and clash with the rollback's create-or-replace logic.
+- Users mix `--wait true` and `--wait false` invocations without realizing Helm history is now poisoned.
+
+**How to avoid:**
+- v2 should make `--wait` and `--atomic` either **both on** or **both off**, controlled by a single `SAFE_UPGRADE: true` (default) flag. Internally this maps to `--atomic --wait --cleanup-on-fail --timeout {TIMEOUT}`. Document that opting out (`SAFE_UPGRADE: false`) is for advanced users only.
+- When `ACTION=rollback` is invoked, refuse to roll back to a revision whose `helm status <release> --revision <n>` shows resources not in `deployed` phase. Surface: `Cannot rollback: revision 4 was deployed without --wait and its resource state is indeterminate. Pass FORCE_ROLLBACK=true to proceed anyway.`
+- For `HISTORY_MAX`: enforce a minimum of 5 (warn if consumer sets less than 5), and document that low history defeats safe rollback.
+- Bundle `helm-diff` (already planned for `DRY_RUN`) and use it pre-rollback to show the consumer what the rollback will actually change — surfaces "rolling back to a broken state" before it happens.
+
+**Warning signs:**
+- Pipe code that exposes `--wait` and `--atomic` as independent toggles without coupling.
+- `HISTORY_MAX` defaulting below 5.
+- Rollback path with no pre-flight resource-status check.
+- Integration tests on `kind`/`k3d` that never exercise a rollback after a `--no-wait` upgrade.
+
+**Phase to address:**
+Phase: **Rollback subcommand** + **History pruning (issue #17)**. These two ship together or not at all; treat as a single workstream.
+
+---
+
+### Pitfall 4: Cosign keyless signing tied to GitHub Actions OIDC + transparency log breaks under three predictable failure modes
+
+**What goes wrong:**
+Three coupled failure modes that each kill the release pipeline silently or annoyingly:
+
+1. **Missing `id-token: write` permission.** The workflow inherits the repo default token permissions; if `permissions:` is set at job level for anything else, `id-token: write` is dropped and the Fulcio cert request fails with `error getting signer: getting key from Fulcio: getting key: invalid character '<' looking for beginning of value` (an HTML error page parsed as JSON — opaque).
+2. **Rekor write succeeds, verify-time Rekor read fails.** Downstream consumers running `cosign verify` against the public Rekor endpoint experience verification failures during Sigstore outages — and there is no offline fallback unless we publish a **signed Rekor bundle** alongside the image (`--bundle` flag during signing, `--offline` flag during verify).
+3. **Private image signing requires `--force`** on cosign versions prior to 1.4 (we will be on a much newer version, but consumer docs that copy-paste from blog posts may hit the old behavior). More relevant for us: the signing workflow must explicitly disable Docker Hub rate limit-induced `manifest unknown` retries that look like signing failures.
+
+Cross-cutting: Fulcio certificates are valid for ~10 minutes. If the signing step runs after a long buildx step, the cert can expire mid-sign with a confusing error.
+
+**Why it happens:**
+- `permissions:` in GitHub Actions is a known footgun — once you set any permission at job level, everything else defaults to `none`.
+- Public Sigstore infra has had outages (documented); teams treat it as if it had Google-level uptime.
+- Cert expiry during long jobs is undocumented in most cosign tutorials.
+
+**How to avoid:**
+- Workflow template: when setting `permissions:`, set them at the **workflow** level explicitly with `id-token: write` and `contents: write` and `packages: write`, and never override at job level for signing jobs. Add a comment in the workflow file warning maintainers about the inheritance footgun.
+- Always sign with `--bundle <path>` and publish the bundle as a GitHub Release asset **and** as an OCI attestation alongside the image. Document the offline-verify path for consumers.
+- Sign **immediately after push** — separate job for buildx (no signing), separate job for sign-and-push-attestation (cosign only). Each job is short, so cert expiry is a non-issue.
+- Pin `cosign` version explicitly in the workflow (not `@latest`).
+- Verify signatures in CI on **every** PR — catches "we forgot to sign" and "the workflow lost id-token permission" before release.
+
+**Warning signs:**
+- A workflow file with `id-token: write` set at job level but the job depends on artefacts from another job that did not have it.
+- No verification step in CI — only signing.
+- Cosign step that runs >5 minutes after `buildx` push.
+- Docs that tell consumers to verify against `rekor.sigstore.dev` directly without an offline-bundle fallback.
+
+**Phase to address:**
+Phase: **Supply-chain modernization** (Cosign + SBOM + Trivy gate). Verification-in-CI must be a sub-task, not "we'll add it later."
+
+---
+
+### Pitfall 5: Multi-arch image build under QEMU silently produces working `amd64` and broken `arm64` because the Python wheel mismatch is invisible until runtime
+
+**What goes wrong:**
+`docker buildx build --platform linux/amd64,linux/arm64 -t ...` on a GitHub Actions `ubuntu-latest` runner uses QEMU emulation for the non-native arch. Three things go wrong:
+
+1. **Build time explodes** for `arm64` (20+ minutes for any C-extension Python package — `cryptography`, `MarkupSafe`, `PyYAML` C bindings). The CI job hits the 6-hour limit on a bad day, or just makes every release slow enough that engineers stop releasing.
+2. **`musl` + `alpine` + `arm64` + Python C extensions = wheel cache misses**. Many wheels exist for `manylinux_2_28_aarch64` but not for `musllinux_1_2_aarch64`. The build silently falls back to compiling from source; some C extensions fail to find ARM-specific headers and the build emits a "no wheel, compiling..." warning that nobody reads.
+3. **Base-image arch mismatch.** If `FROM python:3-alpine` resolves a manifest-list, fine. If it resolves a single-arch image (older custom bases, or a typo'd tag), buildx silently uses the same arch for both targets and the `arm64` image is actually an `amd64` binary tagged `arm64`. It works in `docker run` on a Mac (Rosetta), fails on EKS Graviton with `exec format error`.
+
+For v2 specifically, the pipe runs **inside a Bitbucket Pipelines runner** which is **always `amd64`** today, so the consumer never sees the bug — but Apple Silicon developers pulling the image locally hit it immediately. The bug report will say "image won't run on my Mac" and we will assume Docker Desktop weirdness.
+
+**Why it happens:**
+- QEMU is the default, transparent, and slow. Nobody notices until release N+3.
+- `alpine` is chosen for image size (15 MB vs 120 MB Debian slim) without measuring the build-time tradeoff for our specific deps.
+- The base-image-not-a-manifest-list gotcha is buried in buildx docs.
+
+**How to avoid:**
+- Use `docker/setup-buildx-action` + `docker/build-push-action@v6` with `platforms: linux/amd64,linux/arm64`, **and** verify the resulting manifest list explicitly post-push: `docker buildx imagetools inspect $IMAGE | grep -E 'linux/(amd64|arm64)'` as a CI assertion. Fail the job if either arch is missing.
+- Switch to **native ARM runners** for the `arm64` build. GitHub Actions offers `ubuntu-24.04-arm` runners; use a matrix strategy with one job per arch on native hardware, then `docker buildx imagetools create` to fuse the manifest list. Eliminates QEMU entirely.
+- Pin the base image by **digest**, not tag (`python:3.12-alpine@sha256:...`), so the manifest-list-vs-single-arch behavior is locked at the digest level. Renovate/Dependabot updates the digest.
+- Smoke test on **both** arches in CI: pull the image on an `arm64` runner and run `/opt/pipe/pipe.py --help`. Catches "wrong-arch binary at right-arch tag" instantly.
+- Measure build time: if `arm64` build > 10 minutes, the CI flow has degraded and we missed a wheel availability change — add a build-duration assertion.
+
+**Warning signs:**
+- Single-job buildx with `--platform linux/amd64,linux/arm64` and no post-build manifest assertion.
+- Base image referenced by tag only (`python:3-alpine`) rather than tag-and-digest.
+- Build logs containing `building wheel for cryptography (PEP 517)` — means QEMU cross-compile is happening; switch to native runners.
+- No `arm64` smoke test in CI.
+
+**Phase to address:**
+Phase: **Multi-arch image build** + **GitHub Actions release pipeline**. The native-runners decision should be made before the buildx workflow is written.
+
+---
+
+## Technical Debt Patterns
+
+| Shortcut | Immediate Benefit | Long-term Cost | When Acceptable |
+|----------|-------------------|----------------|-----------------|
+| Keep `awscli` for one transient command "just to unblock release" | No need to rewrite `eks.get_token` path now | Drags `awscli ~1.32` back into the image, contradicts the Key Decision in PROJECT.md, breaks the latency Constraint, eats 120 MB | Never. Cited as a Key Decision; reversal requires an ADR. |
+| Stub `--bundle` cosign output, "we'll wire offline verify later" | Sign workflow ships earlier | Consumers cannot verify during Sigstore outages, undermines the whole supply-chain Phase | Never — verification is a deliverable of the same phase. |
+| Skip `kind`/`k3d` integration tests, rely on acceptance tests only | Faster CI | Helm-rollback pitfalls (Pitfall 3) cannot be reproduced; acceptance tests mock Helm | Never for v2.0 — 100% coverage + integration are validated requirements. |
+| Default `HISTORY_MAX` to Helm's stock 10 without warning if consumer overrides below 5 | Matches Helm defaults exactly | Reintroduces Pitfall 3 (rollback to pruned revision) | Acceptable if consumer warning fires on `< 5`. |
+| Ship v2.0 with `:latest` pointing to v2 | "Modern" tag hygiene | Breaks every consumer using `:latest`; contradicts the "v1.x pinned image keeps working forever" promise | Never. `:latest` stays at v1.3.0 indefinitely until a v2 adoption signal exists. |
+| Use `BaseException` subclasses for one more release "to minimize diff" | Smaller initial refactor PR | Catches `KeyboardInterrupt` and `SystemExit`, blocks Ctrl-C in local dev, listed explicitly as a v1.x bug to fix | Never in v2. Listed in Active requirements. |
+| Bundle `helm-diff` plugin "later" (after MVP) | Faster MVP | Breaks DRY_RUN feature; Pitfall 3 mitigation depends on diff visibility | Acceptable only if `DRY_RUN` is also deferred — they ship together. |
+| Skip signed-commit enforcement on `main` "while the team is small" | Faster contribution onboarding | Listed as a hard maintainer constraint (`commit.gpgsign=true`); violation = norm erosion | Never. Maintainer constraint. |
+
+## Integration Gotchas
+
+| Integration | Common Mistake | Correct Approach |
+|-------------|----------------|------------------|
+| Bitbucket OIDC → AWS STS | Wildcard `sub` in trust policy | Pin `sub` to repo+step UUIDs; provide a fillable template (see Pitfall 1) |
+| EKS `get-token` via boto3 | Use stale `aws-iam-authenticator` token format (`v1alpha1`) | Emit `client.authentication.k8s.io/v1beta1` (current EKS-supported version); regenerate token per `helm` call, do not cache across `--wait` window |
+| OCI chart registry login | `helm registry login` once, assume creds persist across pipe invocations | The pipe runs in a fresh container per step; always login at the start, parameterize `REPO_URL` + `REPO_USERNAME` + `REPO_PASSWORD` and validate they are set when `CHART` starts with `oci://` or `repo://` |
+| `ghcr.io` vs Docker Hub auth in CI | Reuse `DOCKERHUB_TOKEN` for both registries | `ghcr.io` uses `GITHUB_TOKEN` with `packages: write`; Docker Hub uses a separate PAT. Two distinct `docker login` steps in the release workflow, each gated on the registry being targeted. |
+| Bitbucket Pipes Toolkit env schema | Loose schema (`required: false` everywhere) | Use `pipes_toolkit` schema with `type` and `required` set per variable; validate at startup and surface a single consolidated error message, not N stack traces |
+| Helm OCI charts pulled through a proxy | Assume `helm pull oci://` honors `HTTPS_PROXY` | Helm OCI client honors `HTTPS_PROXY` only since 3.13; pin Helm version in image and document the minimum |
+| Cosign + private Docker Hub repo | Forget `--force` for keyless signing of private images on older cosign | Pin cosign ≥ 2.x in workflow; document that `--force` is no longer required |
+| AWS session tags in OIDC trust | Forget `sts:TagSession` in the role's trust policy | Include `sts:TagSession` only if the pipe actually tags sessions; otherwise omit explicitly (least privilege) |
+
+## Performance Traps
+
+| Trap | Symptoms | Prevention | When It Breaks |
+|------|----------|------------|----------------|
+| Full `awscli` install in the image | Cold pipe start > 60s (Constraint violation) | `boto3`-only EKS token generation (Key Decision) | Already broken at v1.x baseline; v2 fixes |
+| QEMU-emulated ARM build | CI release jobs > 20 minutes | Native ARM runners + matrix | When wheels for new deps stop covering musllinux/arm64 |
+| Acceptance test rebuilds image per test | CI > 10 minutes per push | Build once per CI run, share via `actions/cache` or registry tag | At ≥ 5 acceptance tests; current acceptance suite already trends here |
+| Helm `--history-max` set to default 10 with daily deploys | After 10 days, all rollback targets are post-breakage | Document min `HISTORY_MAX: 5` and pair with `--atomic --wait --cleanup-on-fail` | Within 2 weeks of adoption by a daily-deploy consumer |
+| Rekor verify on every pull in consumer's CI | Every `cosign verify` makes a network call to public Rekor | Offline `--bundle` published alongside image | During Sigstore outages or in air-gapped consumer environments |
+| `helm upgrade --wait` with `--timeout 5m` on slow EKS pull | Pipe times out before pod is healthy because image pull is slow | Allow `TIMEOUT` ≥ 10m default; document interaction with EKS node-image-prefetch | Consumers with private ECR + cold nodes |
+
+## Security Mistakes
+
+| Mistake | Risk | Prevention |
+|---------|------|------------|
+| Trust policy with wildcard `sub` or no `aud` constraint | Any Bitbucket workspace can assume the role | Pinned template + docs reviewed by a security-minded reviewer; CI script that fails the docs build if `"*"` appears in trust-policy examples |
+| Logging `BITBUCKET_STEP_OIDC_TOKEN` or `AWS_SESSION_TOKEN` on error | Token exposure in public CI logs | Centralized log scrubber that redacts known secret env-var names; test that scrubber covers OIDC token specifically |
+| Static AWS keys remain the documented "easy path" in v2 README | New consumers adopt the insecure path | OIDC is the **first** auth example in the README; static keys are explicitly labelled "legacy fallback — prefer OIDC" |
+| Docker image signed but SBOM not signed | Supply chain claim is incomplete | Sign SBOM as an OCI attestation with cosign; consumers verify both |
+| `pip-audit`/Trivy as informational only | CVEs ship to consumers | Both are CI **gates** (Validated requirement); failing scan blocks release-please from creating the release PR merge |
+| Auto-merge enabled on Dependabot major bumps without integration test gate | A bad major bump ships to consumers automatically | Auto-merge only when **both** unit AND `kind`/`k3d` integration tests pass; major bumps additionally require Trivy clean |
+| Forget to set `pull_request_target` worries on Cosign signing workflow | Forks can mint OIDC tokens with workflow's identity | Sign only on `push` to `main` and `release` events, never `pull_request_target` |
+| `helm` charts pulled from arbitrary OCI registry without verification | Tampered chart deploys to EKS | Document `cosign verify` for charts where the publisher signs them; not a v2 hard requirement but called out in docs |
+
+## UX Pitfalls
+
+| Pitfall | User Impact | Better Approach |
+|---------|-------------|-----------------|
+| Cryptic `helm` errors passed through verbatim | Consumer cannot tell pipe-error from helm-error | Prefix all pipe-emitted errors with `[aws-eks-helm-deploy]`; pass through helm stderr but bracket it `--- helm stderr ---` / `--- end helm stderr ---` |
+| Migration guide buried under docs root | Consumers miss it during upgrade | Link from the README's "Upgrading from v1.x" section as the **first** post-install heading |
+| `DRY_RUN: true` outputs a 3000-line `helm diff` and breaks Bitbucket log limits | Consumer cannot scroll the diff | Cap diff output at N kB and link to a downloadable artefact attached as a pipe output variable |
+| `ACTION=rollback` without `REVISION` rolls back to "previous" by default | Consumer accidentally rolls back the wrong release | Make `REVISION` mandatory when `ACTION=rollback`; refuse to default |
+| `INJECT_BITBUCKET_METADATA: false` default in v2 with no warning on first run after v1.x | Silent template failure (Pitfall 2) | Smart-detect prior-release dependency on `bitbucket.*` keys and warn (see Pitfall 2) |
+| OCI chart `CHART_VERSION` accepting non-pinned semver ranges (`^1.2.0`) | Reproducibility lost | Reject anything but a fully-pinned version; document the rationale (production deployments must be reproducible) |
+| Pipe outputs nothing on success | Consumer cannot verify what changed | Always emit: release name, revision number, app version, namespace, and (if `DRY_RUN`) the diff |
+
+## "Looks Done But Isn't" Checklist
+
+- [ ] **AWS OIDC**: Token validation step in pipe — verify `aud` claim shape; do not rely on STS to surface the error. Test: invoke with a hand-rolled JWT whose `aud` is an array; assert pipe-side rejection.
+- [ ] **OCI chart support**: `helm registry login` is called before any `helm pull oci://`; `CHART_VERSION` is mandatory when `CHART` starts with `oci://`. Test: integration test pulling a real chart from `ghcr.io`.
+- [ ] **Multi-arch image**: Post-build `docker buildx imagetools inspect` assertion in CI that both `linux/amd64` and `linux/arm64` manifests exist. Test: CI step that fails if either is missing.
+- [ ] **Cosign signing**: Signature **and** SBOM attestation **and** Rekor bundle published per release. Test: a verification job in the same workflow runs `cosign verify --offline --bundle` against the freshly-signed image.
+- [ ] **Migration guide**: Every breaking-change row has a before/after `bitbucket-pipelines.yml` diff. Test: docs-build script greps for `INJECT_BITBUCKET_METADATA`, `NAMESPACE`, and any renamed env var; fails if any are missing from the migration guide.
+- [ ] **Rollback subcommand**: Pre-flight check that the target revision was deployed with `--wait` (status check). Test: integration test on `kind` that rolls back to a `--no-wait` revision and asserts pipe refuses unless `FORCE_ROLLBACK=true`.
+- [ ] **`release-please` setup**: Conventional-commit footers (`BREAKING-CHANGE:`) bump major; squash-merge enforced on PR; release PR auto-updates as commits land. Test: a dry-run PR that lands a `feat!:` commit and verifies the release-please PR proposes a major bump.
+- [ ] **OCI image labels**: All OCI annotations populated (`org.opencontainers.image.source`, `revision`, `licenses`, `description`, `version`, `created`). Test: `docker buildx imagetools inspect --raw | jq` assertion in CI.
+- [ ] **`boto3`-only EKS token**: No `awscli` in `pyproject.toml` final lockfile. Test: lockfile audit step in CI greps for `awscli` and fails.
+- [ ] **`helm-diff` plugin bundled**: `DRY_RUN` path works without network access to plugin registry. Test: integration test runs `DRY_RUN: true` with no internet (kind cluster + offline) and asserts diff is emitted.
+- [ ] **Trivy/Grype gate**: Vulnerability scan is a **blocking** CI step, not informational. Test: an intentionally vulnerable PR fails the gate (one-time fixture).
+- [ ] **`:latest` tag policy**: A documentation note **and** a release-workflow guard that prevents `:latest` from being pushed to v2 images.
+
+## Recovery Strategies
+
+| Pitfall | Recovery Cost | Recovery Steps |
+|---------|---------------|----------------|
+| OIDC trust policy too permissive (Pitfall 1) | LOW (security incident pending) | Patch docs immediately; consumers re-deploy with corrected trust policy; rotate any AWS role that was abused (review CloudTrail for unexpected `AssumeRoleWithWebIdentity` events) |
+| Metadata-injection default silently broke consumers (Pitfall 2) | MEDIUM | Hotfix release v2.0.1 with a louder warning **and** a one-page upgrade troubleshooting doc; pin a Discord/issue triage for 1 week |
+| Helm rollback corrupted a release (Pitfall 3) | HIGH (production outage) | Manual `helm history` review; `kubectl apply -f` last-known-good manifests from backup; document the recovery as a runbook |
+| Cosign verify failing due to Sigstore outage (Pitfall 4) | LOW | Publish offline bundle alongside every release; consumer docs link to `cosign verify --offline --bundle` recipe |
+| `arm64` image is actually `amd64` (Pitfall 5) | LOW | Republish v2.0.x with fixed buildx workflow; add the inspect-manifest CI gate as a regression test |
+| `release-please` PR went off the rails (force-pushed a wrong version) | MEDIUM | Revert the version-bump commit on `main`; manually craft the next release PR; ensure branch protection blocks force-push to `main` going forward |
+| Dependabot auto-merged a broken major bump | MEDIUM | Revert PR, pin dependency, file an issue against the dep; review auto-merge criteria |
+| Static AWS keys still in use after v2 ships | LOW (security debt) | Migration guide emphasizes OIDC; static-keys-path emits a deprecation log line (not a hard break in v2.0; flagged for v2.1 removal) |
+
+## Pitfall-to-Phase Mapping
+
+| Pitfall | Prevention Phase | Verification |
+|---------|------------------|--------------|
+| 1. OIDC `aud`/`sub` misconfiguration | AWS OIDC / IRSA implementation | Pipe-side `aud` validation unit test; docs build greps for `"*"` in trust-policy examples |
+| 2. `INJECT_BITBUCKET_METADATA` silent break | Opt-in metadata injection (issue #16) + Migration guide | Integration test asserts warning fires when prior release had `bitbucket.*` keys |
+| 3. Helm rollback on non-`--wait` revision | Rollback subcommand + History pruning (issue #17) | `kind`/`k3d` integration test rolls back to a `--no-wait` revision and asserts refusal |
+| 4. Cosign / GitHub Actions OIDC failure modes | Supply-chain modernization (Cosign + SBOM + Trivy) | Workflow has a verify step on every PR; `--bundle` published per release |
+| 5. Multi-arch QEMU silent breakage | Multi-arch image build + GitHub Actions release pipeline | Post-build `imagetools inspect` assertion; `arm64` runner smoke test |
+| Bitbucket Pipes Toolkit env-schema loose | Modernization baseline (schema + pyproject) | Strict schema validation at pipe start with consolidated error |
+| `awscli` import fragility | Modernization baseline (`boto3`-only EKS token) | Lockfile audit step; unit tests cover token generation against moto |
+| `ghcr.io` vs Docker Hub auth divergence | GitHub Actions release pipeline | Separate `docker login` steps; release fails fast if either secret is missing |
+| OCI chart auth | Helm repository and OCI chart support (issue #7) | Integration test pulls signed chart from `ghcr.io` |
+| `release-please` mis-bumps version | GitHub Actions release pipeline | Branch protection on `main` (signed commits, no force-push); release-please config reviewed; `BREAKING-CHANGE:` footer convention documented in `CONTRIBUTING.md` |
+| Acceptance tests rebuild image per test | Test-suite migration | Cache built image across acceptance tests via OCI tag |
+| `:latest` tag drift | Distribution modernization | Release workflow refuses to push `:latest` for v2 images |
+
+## Sources
+
+- [Bitbucket OIDC with AWS (Towards The Cloud)](https://towardsthecloud.com/blog/aws-cdk-openid-connect-bitbucket) — `aud` claim shape and trust policy structure
+- [Atlassian: Deploy on AWS using Bitbucket Pipelines OpenID Connect](https://support.atlassian.com/bitbucket-cloud/docs/deploy-on-aws-using-bitbucket-pipelines-openid-connect/) — official audience URL format
+- [AWS STS now supports validation of IdP-specific claims (2026-01)](https://aws.amazon.com/about-aws/whats-new/2026/01/aws-sts-supports-validation-identity-provider-claims) — recent STS behavior change relevant to OIDC trust policies
+- [Helm issue #9490 — ideal flags for upgrade/rollback failure handling](https://github.com/helm/helm/issues/9490) — community pattern for `--atomic` + `--wait` + `--cleanup-on-fail`
+- [Helm upgrade docs](https://helm.sh/docs/v3/helm/helm_upgrade/) — `--history-max`, `--atomic`, `--wait` semantics
+- [Handling failed Helm upgrade due to another operation in progress](https://www.kristhecodingunicorn.com/post/helm-upgrade-failure-another-operation-in-progress/) — locked-release recovery
+- [Sigstore Cosign Keyless Signing with GitHub Actions OIDC: Complete Guide (QC Securing)](https://www.qcecuring.com/blog/sigstore-cosign-keyless-github-actions) — `id-token: write` and Rekor specifics
+- [Sign Your Container Images with Cosign, GitHub Actions and GHCR (DEV.to / Christian Dennig)](https://dev.to/n3wt0n/sign-your-container-images-with-cosign-github-actions-and-github-container-registry-3mni) — workflow permission inheritance footgun
+- [Faster Docker builds for Arm without emulation (Depot)](https://depot.dev/blog/docker-arm) — QEMU vs native ARM runners performance gap
+- [Alpine Python Docker: Multi-Arch Buildx Manifests 2025](https://www.johal.in/alpine-python-docker-multi-arch-buildx-manifests-2025/) — Python-on-Alpine wheel availability
+- [Docker multi-platform builds docs](https://docs.docker.com/build/building/multi-platform/) — manifest-list base-image pitfall
+- [release-please documentation](https://github.com/googleapis/release-please) — `BREAKING-CHANGE:` footer and squash-merge convention
+- [release-please-action](https://github.com/googleapis/release-please-action) — GitHub Actions integration patterns
+- [aws-iam-authenticator (kubernetes-sigs)](https://github.com/kubernetes-sigs/aws-iam-authenticator) — EKS token format and `v1beta1` requirement
+- [boto3 credentials docs](https://docs.aws.amazon.com/boto3/latest/guide/credentials.html) — `AssumeRoleWithWebIdentity` caching and refresh
+- [Helm OCI Registry Integration (DeepWiki)](https://deepwiki.com/helm/helm/6.2-oci-registry-integration) — OCI chart pull / login semantics
+- Existing v1.x source: `pipe/{pipe.py, schema.py, eks/, helm/}` — `BaseException`, `awscli.customizations.eks.get_token`, no `--wait`/`--atomic` coupling, `NAMESPACE` default inconsistency
+
+---
+*Pitfalls research for: Bitbucket Pipelines Pipe (Helm-to-EKS) v2.0 modernization*
+*Researched: 2026-06-16*

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -1,0 +1,264 @@
+# Stack Research
+
+**Domain:** CI-pipeline Docker container (Python) wrapping `helm` + AWS SDK, distributed as a Bitbucket Pipes Marketplace pipe; primary forge = GitHub
+**Researched:** 2026-06-16
+**Confidence:** HIGH (toolchain), MEDIUM (docs system — Material-for-MkDocs is in maintenance mode; safe for 12-18 months but Zensical migration looms)
+
+## Scope Reminder
+
+This stack covers the **v2.0 modernization**: replacing v1.3.0's ad-hoc `requirements.txt` + `awscli` + `semversioner` + Bitbucket-Pipelines-only setup with a 2026 SOTA equivalent. The v1.x stack is treated as the baseline being replaced; recommendations below are the targets.
+
+---
+
+## Recommended Stack
+
+### (A) Runtime / Container
+
+| Technology | Version | Purpose | Why Recommended |
+|------------|---------|---------|-----------------|
+| Python | **3.13** (CPython, on slim image) | Pipe runtime | 3.13 is the current security-supported minor (3.14 lands EOL-2030); 3.13 has the new free-threading prelude and stable `typing.TypedDict` features used by `pyproject.toml` consumers. v1.x runs on `python:3-alpine` which floats — pinning to 3.13 fixes the implicit-bump foot-gun. |
+| Base image | **`python:3.13-slim-bookworm`** (Debian) | Build & runtime | Switch away from `alpine`. Alpine's musl libc is a perennial source of `boto3`/`urllib3`/`grpcio` wheel-availability and DNS-resolution bugs, and the savings vs. Debian-slim are ~20 MB after multi-stage build. For an Apache-2.0 OSS pipe used by 9+ public consumers, fewer surprises > 20 MB. |
+| Helm | **3.18.x** (latest stable in the 3.x line) | Chart engine | Bump from v1.x's pinned `3.15.1`. 3.16+ is required for the OIDC/IRSA and OCI-stable feature matrix the project commits to. Use `alpine/helm:3.18` as a build-stage source and `COPY --from=...` the binary into the Debian runtime — avoids re-implementing Helm-build logic. |
+| `helm-diff` plugin | **3.10.x** | `DRY_RUN` preview | Required by the new `DRY_RUN` feature (PROJECT.md "Active"). Install via `helm plugin install` during image build. |
+| `aws-iam-authenticator` | **NOT USED** | — | Not needed. `boto3` + a hand-rolled presigned-URL `eks get-token` (see (B)) eliminates the binary entirely. |
+
+### (B) Python Application Dependencies
+
+| Library | Version | Purpose | Why Recommended |
+|---------|---------|---------|-----------------|
+| `boto3` | **~=1.40** | AWS SDK | Replaces full `awscli ~=1.32` (~120 MB saved per PROJECT.md "Key Decisions"). Generate the EKS token by signing an STS `GetCallerIdentity` presigned URL (the documented mechanism — `kind: ExecCredential` payload that `aws eks get-token` produces is reproducible in ~30 lines of Python). |
+| `botocore` | (transitive via `boto3`) | low-level signer | Used directly for the EKS-token presigning step (`botocore.signers.RequestSigner`). |
+| `eks-token` | **~=0.4** (OR roll our own) | Optional helper | If we want zero hand-rolled crypto, the `eks-token` PyPI package wraps the STS-presign flow in one call. **Recommendation: roll our own (~30 LOC)** — adds an ADR-worthy decision, but kills another transitive dependency and we already need typed `boto3` calls. Mark as **MEDIUM confidence**: revisit if the token logic grows beyond 50 LOC. |
+| `bitbucket-pipes-toolkit` | **~=4.6** (latest) | Pipe contract / env-var handling / logging | Required by the Bitbucket Pipes Marketplace listing — non-negotiable. Bump from v1.x's `~=4.4`. |
+| `Jinja2` | **~=3.1** | kubeconfig + values templating | Already used in v1.x for kubeconfig rendering; keep. No SOTA replacement that is materially better for this small templating surface. |
+| `PyYAML` | **~=6.0** | YAML parsing for chart values / `pipe.yml` | Standard. Used implicitly via `bitbucket-pipes-toolkit` already; pin explicitly. |
+| `pydantic` | **NOT USED** for v2.0 | — | Tempting for schema validation, but `bitbucket-pipes-toolkit` already has its own `schema` validator and adding Pydantic v2 bloats the wheel set for marginal value. Revisit if schema complexity grows. **Mark MEDIUM: reconsider in v2.1.** |
+| `awscli` | **REMOVED** | — | Per PROJECT.md "Key Decisions". Drop entirely. |
+
+### (C) Development Toolchain
+
+| Tool | Version | Purpose | Why Recommended |
+|------|---------|---------|-----------------|
+| **`uv`** | **0.11.x** (latest 0.11 line) | Env + dependency + lock + project manager | **Decision: `uv` over `poetry`/`pdm`.** `uv` is 10-100× faster than poetry, writes a PEP 751-compatible `uv.lock`, supports `uv sync --frozen --no-dev` for reproducible Docker builds, and is the default in 2026 greenfield Python. Yves' user-global rules favor `uv` explicitly. Confidence: **HIGH**. |
+| **`ruff`** | **0.15.x** (latest, ships the "2026 style guide") | Lint + format + import-sort | **Decision: `ruff` replaces `black + isort + flake8 + pyupgrade + pydocstyle` entirely.** One binary, one config (`[tool.ruff]` in `pyproject.toml`), single source of truth. Ruff 0.15's formatter is now a fully credible Black replacement. Confidence: **HIGH**. |
+| **`mypy`** | **~=1.18** with `--strict` | Static type-check | **Decision: `mypy --strict` over `pyright`.** Rationale: (1) `mypy` runs natively as a Python tool — fits the `uv`-managed dev env without a Node toolchain; (2) the 1.18+ mypyc-compiled wheel is now competitive with pyright on speed; (3) `boto3-stubs` and `bitbucket-pipes-toolkit` ecosystem integration is better tested under mypy. **Caveat**: if dev experience suffers, fall back to `basedpyright` (the community fork with strict-by-default) — leave that as an escape hatch. Confidence: **HIGH** for mypy, MEDIUM for the no-pyright recommendation. |
+| `boto3-stubs[eks,sts]` | **latest** | Type stubs for the only AWS services we touch | Required for `mypy --strict` to type-check `boto3` calls. Only install the `eks` + `sts` extras — full `boto3-stubs[essential]` is ~80 MB. |
+| `pytest` | **~=8.4** | Test runner | Industry default; v1.x already uses it for acceptance tests. |
+| `pytest-cov` | **~=7.1** | Coverage | Wraps `coverage.py`. Required for the 100% line+branch coverage goal. Configure with `--cov-branch --cov-fail-under=100`. |
+| `pytest-mock` | **~=3.14** | `mocker` fixture | Cleaner than `unittest.mock.patch` decorators for mocking `subprocess`, `boto3` clients, and the Helm wrapper. |
+| `pytest-xdist` | **~=3.6** | Parallel test execution | Speeds the unit suite on CI. Mark `-n auto` in `pyproject.toml` once the suite >50 tests. |
+| `moto` | **~=5.x** | AWS service mocking | Mocks EKS `describe_cluster` and STS `assume_role`/`assume_role_with_web_identity` end-to-end. Far better than hand-mocking boto3 clients with `pytest-mock`. |
+| `responses` | **NOT USED** initially | HTTP mock | Only if we end up making non-boto3 HTTP calls (e.g. for Helm OCI repo auth). Defer. |
+| `coverage[toml]` | **~=7.6** | Underlying coverage engine | Pulled by `pytest-cov`; configure via `[tool.coverage.*]` in `pyproject.toml`. |
+| `kind` | **0.30.x** | Local k8s for integration tests | Industry default for "real kubectl/helm in CI"; runs on GitHub Actions ubuntu-24.04 runners in <90s. Use over `k3d` because the Kubernetes-SIG-owned project has the most stable release cadence and best GHA integration. **Alternative: `k3d`** — slightly faster startup, smaller footprint; choose `k3d` if the integration suite exceeds 10 tests and CI time becomes a problem. |
+| `pre-commit` | **~=3.8** | Local git-hook orchestration | Runs `ruff check --fix`, `ruff format`, `mypy`, and `pytest --quiet` on staged files before commit. Integrate with `lefthook` instead if startup time matters; `pre-commit` is the safer default. |
+| `commitizen` | **~=3.x** | Conventional Commits linter | Optional — but Yves' user-global rules mandate Conventional Commits everywhere. `cz check --rev-range origin/main..HEAD` in CI gates non-conforming commits cleanly. Confidence: **MEDIUM** (could also be enforced via release-please's PR-title-linter alone). |
+
+### (D) Release Automation
+
+| Tool | Version | Purpose | Why Recommended |
+|------|---------|---------|-----------------|
+| **`googleapis/release-please-action`** | **v4** | Conventional-Commits → SemVer release PRs | **Decision: `release-please` over `python-semantic-release`.** Already locked in PROJECT.md "Key Decisions". Rationale: (1) PR-based release flow (release-PR is reviewable, signed-commit-friendly — matches Yves' "GPG-signed commits / no direct main" rules); (2) GitHub-native, no extra runtime to install; (3) updates `pyproject.toml`, `CHANGELOG.md`, and `pipe.yml` version field in a single PR via `extra-files`. **Config:** `release-type: python`, `package-name: aws-eks-helm-deploy`, `extra-files: [pipe.yml, README.md]` (use the `$schema`/regex form to bump the `image:` tag in `pipe.yml`). Confidence: **HIGH**. |
+| `semversioner` | **REMOVED** | — | Per PROJECT.md "Out of Scope". Drop `.changes/` directory after migration. |
+| `python-semantic-release` | **NOT USED** | — | Strictly Python-centric and pushes tags directly to `main` — conflicts with branch protection + release-PR review flow. |
+
+### (E) Docker / Image Build
+
+| Tool | Version | Purpose | Why Recommended |
+|------|---------|---------|-----------------|
+| `docker/setup-buildx-action` | **v3** | Buildx in GHA | Required for multi-arch + layer cache. |
+| `docker/setup-qemu-action` | **v3** | ARM64 emulation | Use **only** if we keep single-runner builds. For sub-2-minute builds, prefer the **native-runner-per-arch** pattern (one job on `ubuntu-24.04`, one on `ubuntu-24.04-arm`, then `buildx imagetools create` to assemble the manifest list). Confidence: **HIGH** that native-per-arch is the 2026 best practice; **MEDIUM** that the public GHA `ubuntu-24.04-arm` runner availability is sufficient for an Apache-2.0 OSS project (it is, as of June 2026). |
+| `docker/build-push-action` | **v6** | Build + push | Layer cache via `cache-from: type=gha,scope=...` + `cache-to: type=gha,mode=max`. |
+| `docker/metadata-action` | **v5** | OCI labels + tag derivation | Emits `org.opencontainers.image.*` annotations (closes PROJECT.md "OCI image labels" requirement). Configure `tags:` to emit `latest`, `vX.Y.Z`, `vX.Y`, `vX`. |
+| `docker/login-action` | **v3** | Registry auth | For both Docker Hub (PAT in secret) and GHCR (`GITHUB_TOKEN` with `packages: write`). |
+
+### (F) Supply-Chain Security
+
+| Tool | Version | Purpose | Why Recommended |
+|------|---------|---------|-----------------|
+| **`cosign`** | **2.4.x** | Keyless image signing + attestations | Sign images with GitHub Actions OIDC → Fulcio short-lived cert → Rekor transparency-log entry. Zero key management. Use `sigstore/cosign-installer@v3` in the workflow. Verify with `cosign verify --certificate-identity-regexp 'https://github\.com/yves-vogl/aws-eks-helm-deploy/\.github/workflows/release\.ya?ml@refs/tags/v.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com <image>`. Confidence: **HIGH**. |
+| **`syft`** | **1.42.x** | SBOM generation | `syft <image> -o spdx-json=sbom.spdx.json -o cyclonedx-json=sbom.cdx.json` — emit **both** formats. SPDX for NTIA/license auditing, CycloneDX for vuln-correlation tools. Attach as a Cosign attestation: `cosign attest --predicate sbom.spdx.json --type spdx <image>`. Confidence: **HIGH**. |
+| **`trivy`** | **0.59.x** | Vulnerability + IaC + secret scan in CI | **Decision: `trivy` over `grype`.** Rationale: (1) one binary covers image vulns + Dockerfile lint + filesystem scan + Helm-chart scan + secret detection — matches our four-axis CI gate; (2) trivy's multi-source DB (NVD + RH + Debian + Ubuntu + Alpine) reduces false negatives on Debian-slim base; (3) `aquasecurity/trivy-action@0.x` is the most mature GHA wrapper. **Caveat:** Trivy is ~18% noisier than Grype on backport-patched CVEs — mitigate with `.trivyignore` + severity gate `HIGH,CRITICAL`. Confidence: **HIGH**. |
+| `grype` | **NOT USED** | — | Better risk-scoring (EPSS+KEV+CVSS) but narrower scope; revisit only if vuln-prioritization becomes a bottleneck. |
+| **`pip-audit`** | **~=2.7** | Python dependency vuln scan | Run `uv run pip-audit --strict` against the locked deps. Complementary to Trivy: pip-audit pulls from PyPI advisory DB which has Python-specific CVEs that trivy can miss. |
+| **`Dependabot`** | (built-in) | Auto-bump | Three ecosystems: `pip` (pyproject.toml), `docker` (Dockerfile FROM tags), `github-actions`. Per PROJECT.md, auto-merge on green is enabled — implement via `dependabot/fetch-metadata` + `gh pr merge --auto`. |
+| `SLSA provenance` | via `actions/attest-build-provenance@v1` | Build attestation | Emits SLSA v1 provenance attached as a Sigstore Rekor entry. Free + zero-config when running on GitHub-hosted runners. Closes the "SLSA level 2+" baseline noted in 2026 supply-chain guidance. |
+
+### (G) Documentation System
+
+| Tool | Version | Purpose | Why Recommended |
+|------|---------|---------|-----------------|
+| **`mkdocs-material`** | **9.5.x** (latest) | Documentation site | **Decision: `mkdocs-material` over Sphinx or README-only.** Rationale: (1) Markdown-first matches Conventional-Commits and PR-review culture; (2) the project is prose-heavy (migration guide, ADRs, `examples/`, OIDC setup) — Sphinx's autodoc/rST strength is wasted on a 5-module pipe; (3) the `mkdocstrings[python]` plugin covers the small API-reference need; (4) GitHub Pages hosting is one workflow step. **Caveat (MEDIUM confidence):** Material-for-MkDocs entered maintenance mode in early 2026; the successor `Zensical` will read existing `mkdocs.yml` configs. Safe for the v2.0 timeline (12-18 months) — migrate to Zensical when the v2.1 docs refresh lands. |
+| `mkdocs-material` plugins | latest | — | `mkdocs-minify-plugin`, `mkdocs-git-revision-date-localized-plugin`, `mkdocs-redirects` (for the `docs/v1/` → `docs/v2/` URL transitions), `mike` (for versioned docs deploy — required by PROJECT.md "versioned documentation"). |
+| `mkdocstrings[python]` | latest | API reference from docstrings | Only needed if we expose any public Python API. For a CLI-style pipe, this is minimal — keep but lightly used. |
+| `Sphinx` | **NOT USED** | — | Overkill for prose-first docs; the rST learning curve cost is real for contributors. |
+| `pdoc` | **NOT USED** | — | Too lightweight; lacks the navigation, search, and versioning Material gives us. |
+| `Zensical` | **WATCH** | future migrant | Track its 1.0 release; migrate when stable (likely late 2026 / early 2027). |
+
+---
+
+## Installation
+
+### Local dev bootstrap
+
+```bash
+# uv (single binary, no Python needed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Project deps + dev tools (declared in pyproject.toml)
+uv sync --all-extras --dev
+
+# Install pre-commit hooks
+uv run pre-commit install --install-hooks
+
+# Local Kubernetes for integration tests
+brew install kind helm  # or: go install sigs.k8s.io/kind@latest
+```
+
+### `pyproject.toml` skeleton (dependency section only)
+
+```toml
+[project]
+name = "aws-eks-helm-deploy"
+requires-python = ">=3.13"
+dependencies = [
+    "boto3 ~= 1.40",
+    "bitbucket-pipes-toolkit ~= 4.6",
+    "Jinja2 ~= 3.1",
+    "PyYAML ~= 6.0",
+]
+
+[dependency-groups]
+dev = [
+    "ruff ~= 0.15",
+    "mypy ~= 1.18",
+    "boto3-stubs[eks,sts]",
+    "pytest ~= 8.4",
+    "pytest-cov ~= 7.1",
+    "pytest-mock ~= 3.14",
+    "pytest-xdist ~= 3.6",
+    "moto[eks,sts] ~= 5.0",
+    "pre-commit ~= 3.8",
+    "pip-audit ~= 2.7",
+]
+docs = [
+    "mkdocs-material ~= 9.5",
+    "mkdocstrings[python]",
+    "mkdocs-minify-plugin",
+    "mkdocs-redirects",
+    "mike",
+]
+```
+
+### CI tool installs (GitHub Actions snippets)
+
+```yaml
+- uses: astral-sh/setup-uv@v3
+- uses: sigstore/cosign-installer@v3
+- uses: anchore/sbom-action@v0   # wraps syft
+- uses: aquasecurity/trivy-action@0.x
+- uses: helm/kind-action@v1       # for integration tests
+- uses: docker/setup-buildx-action@v3
+- uses: docker/build-push-action@v6
+- uses: googleapis/release-please-action@v4
+```
+
+---
+
+## Alternatives Considered
+
+| Recommended | Alternative | When to Use Alternative |
+|-------------|-------------|-------------------------|
+| `uv` | `poetry` | If team is large and already poetry-fluent; not the case here. |
+| `uv` | `pdm` | If you specifically need PEP 582's `__pypackages__` workflow (rare). |
+| `uv` | `pip-tools` + venv | If you want pure-stdlib tooling. Loses 100× speedup and lock-file ergonomics. |
+| `ruff` | `black + isort + flake8` | If a critical Ruff rule is missing or behaves differently (verify per-rule; most projects migrate cleanly). |
+| `mypy --strict` | `pyright` / `basedpyright` | If we want stricter unannotated-code analysis and don't care about plugin ecosystem. **Pyright catches more edge cases (98% spec conformance vs. mypy's ~94%).** Reasonable fallback. |
+| `release-please` | `python-semantic-release` | If we ever lose GitHub-native release-PR flow (e.g. mirror to a non-GH forge as primary — but Bitbucket-as-mirror doesn't need release automation). |
+| `trivy` | `grype` | When risk-scoring (EPSS + KEV + CVSS composite) becomes the gating metric, not coverage breadth. |
+| `mkdocs-material` | `Sphinx` + `furo` theme | If the project ever becomes a Python library with a large public API surface and >50 modules. |
+| `mkdocs-material` | `Docusaurus` | If documentation grows to multi-product and we want React-component embeds. Overkill here. |
+| Native multi-arch (per-runner) | QEMU emulation | If `ubuntu-24.04-arm` runner availability degrades or the arm64 build becomes serial/slow — fall back to single-runner QEMU. |
+| `cosign` keyless | `cosign` keyed | Only if Sigstore public-good infrastructure becomes unreliable (low-probability in 2026). |
+| `kind` | `k3d` | If integration-test startup time exceeds 90s consistently. |
+| Roll our own EKS token | `eks-token` PyPI package | If the presign logic grows past ~50 LOC or we add token-caching/refresh. |
+
+---
+
+## What NOT to Use
+
+| Avoid | Why | Use Instead |
+|-------|-----|-------------|
+| `awscli` as a Python dependency | ~120 MB, drags ancient `urllib3`/`botocore` constraints, internal-import (`awscli.customizations.eks.get_token`) is unsupported | `boto3` + hand-rolled STS-presign for `eks get-token` |
+| `python:3-alpine` (or any unpinned `python:3*`) | musl-libc wheel-availability + DNS-resolver quirks, floating tag causes silent CPython bumps | `python:3.13-slim-bookworm` |
+| `requirements.txt` | No lock file, no dev/prod split, no Python-version constraint | `pyproject.toml` + `uv.lock` |
+| `setup.py` / `setup.cfg` | Deprecated for new projects since PEP 621 | `pyproject.toml` (PEP 621 metadata) |
+| `BaseException` subclasses (carried over from v1.x) | Intercepts `KeyboardInterrupt` + `SystemExit` — debugging hell | `Exception` subclasses; PROJECT.md "Active" flags this explicitly |
+| `flake8` + `black` + `isort` + `pyupgrade` (separate tools) | 4 tools, 4 configs, 4 CI installs, all slower than one Ruff invocation | `ruff check` + `ruff format` |
+| `semversioner` | Yves' v1.x history shows the `.changes/` ceremony adds friction; PR-based release-please is cleaner | `release-please` (already locked in PROJECT.md) |
+| GPG image signing (e.g. Notary v1) | Dead-tech for OCI distribution; no GitHub-native flow | `cosign` keyless (already locked in PROJECT.md) |
+| `docker scan` (Snyk-backed) | License-restricted; degraded free tier in 2025 | `trivy` (Apache-2.0) |
+| `safety` (Python vuln scanner) | Commercial DB; free tier has latency on advisories | `pip-audit` (PyPA-blessed) |
+| `bandit` as a standalone tool | Mostly subsumed by Ruff's `S` (flake8-bandit) rule family | Ruff `select = ["S"]` |
+| `tox` | Multi-Python-version matrix without `uv`'s speed; redundant when we target only 3.13 | `uv run pytest` directly; GHA matrix if we ever multi-version |
+| `sphinx-autoapi` / `pdoc` | Doc-generation tools for projects we aren't — a CLI pipe doesn't need autodoc-heavy docs | `mkdocs-material` + a short `mkdocstrings` section if needed |
+| Building all arches with QEMU on a single runner | Slow (5-10× for arm64); becomes a CI bottleneck as the image grows | Native `ubuntu-24.04-arm` runner + `buildx imagetools create` |
+| Storing the Cosign verification public key in the repo | Defeats the point of keyless | Verify by GitHub OIDC issuer + certificate identity regex |
+| Pushing to Docker Hub only | Single point of distribution, rate-limit risk for consumers | Mirror to GHCR (`ghcr.io/yves-vogl/aws-eks-helm-deploy`) too — PROJECT.md "Active" |
+
+---
+
+## Stack Patterns by Variant
+
+**If the project later adds GitHub Actions as a first-party invocation surface** (currently out-of-scope per PROJECT.md):
+- Add a `action.yml` at the repo root.
+- Add `aws-actions/configure-aws-credentials@v4` to the recommended consumer snippets.
+- Keep the same Python codebase — only the wrapper changes.
+
+**If consumer demand for Azure / GCP grows** (currently AWS-only):
+- Split cloud-provider auth into a `pipe/cloud/` package with `eks.py`, `aks.py`, `gke.py`.
+- Add `azure-identity` and `google-auth` to optional `pyproject.toml` extras.
+- Reconsider Pydantic for the now-multi-shape config schema.
+
+**If Helm-chart vulnerability scanning becomes a required output** (currently only image scanning):
+- Add a `trivy config <chart-dir>` step (Trivy already covers Helm chart scanning).
+- Surface results as a PR comment via `aquasecurity/trivy-action` `format: sarif` + `github/codeql-action/upload-sarif`.
+
+---
+
+## Version Compatibility
+
+| Package A | Compatible With | Notes |
+|-----------|-----------------|-------|
+| `python ~=3.13` | `boto3 ~=1.40` | Full support |
+| `python ~=3.13` | `bitbucket-pipes-toolkit ~=4.6` | Verify on first `uv sync` — toolkit historically lags Python releases by 3-6 months |
+| `helm 3.18` | Kubernetes 1.30, 1.31, 1.32 | Per Helm's version-skew policy (n-3 supported); document the minimum K8s in the README |
+| `helm 3.18` + `helm-diff 3.10` | OK | helm-diff tracks Helm major; 3.x covers Helm 3.x |
+| `mypy 1.18` + `boto3-stubs` | OK | boto3-stubs ships per-service extras; only install `[eks,sts]` to keep image build cache hot |
+| `ruff 0.15` + `pyproject.toml` | OK | All config under `[tool.ruff]` and `[tool.ruff.format]`; remove separate `.ruff.toml` |
+| `release-please v4` + `release-type: python` | Updates `pyproject.toml` `version` and `CHANGELOG.md` | Use `extra-files` to also bump `pipe.yml` (regex form) |
+| `cosign 2.4` + GHA OIDC | Requires `permissions: id-token: write` + `contents: read` (or `write` for releases) | Don't grant `id-token` on PR workflows from forks |
+| `trivy 0.59` + `.trivyignore` | OK | `.trivyignore` syntax is stable since 0.50 |
+| `mkdocs-material 9.5` + `mike` | OK | `mike` handles the `docs/v1/` vs `docs/v2/` versioned-docs requirement |
+| `uv 0.11` + `pyproject.toml` (PEP 621) | OK | `uv.lock` is the project lock file; `requirements.txt` only generated if a consumer needs it (`uv export`) |
+
+---
+
+## Sources
+
+- [astral-sh/uv changelog](https://github.com/astral-sh/uv/blob/main/CHANGELOG.md) — confirmed 0.11.8 (Apr 27 2026) as the current line; **HIGH** confidence
+- [astral-sh/ruff PyPI](https://pypi.org/project/ruff/) and [Ruff 0.15 + 2026 Style Guide](https://www.pyblog.in/programming/ruff-0-15-2026-style-guide-modern-python-formatting-explained/) — Ruff 0.15 (Feb 2026) is the Black-replacement-credible release; **HIGH**
+- [mypy vs Pyright vs ty 2026](https://www.danilchenko.dev/posts/ty-vs-mypy-vs-pyright/) — mypy 1.18 mypyc-compiled now competitive with pyright on speed; **HIGH**
+- [pytest plugins ranking 2026 — PythonTest](https://pythontest.com/top-pytest-plugins/) — pytest-cov/mock/xdist remain the top-4 by downloads as of March 2026; **HIGH**
+- [Trivy vs Grype 2026](https://lucaberton.com/blog/trivy-vs-grype-2026/) and [Container scanning 2026 — HostMyCode](https://www.hostmycode.com/blog/container-image-vulnerability-scanning-strategies-production-security-trivy-grype-snyk-2026) — Trivy = breadth, Grype = depth on prioritization; **HIGH**
+- [Syft SBOM generator 2026](https://appsecsanta.com/syft) — Syft 1.42.0 (Feb 10 2026); SPDX + CycloneDX dual emit best-practice; **HIGH**
+- [Cosign keyless GHA guide](https://www.qcecuring.com/blog/sigstore-cosign-keyless-github-actions) and [chainguard.dev keyless container signing](https://edu.chainguard.dev/open-source/sigstore/how-to-keyless-sign-a-container-with-sigstore/) — id-token:write permission, Fulcio + Rekor flow; **HIGH**
+- [MkDocs vs Sphinx 2026](https://gautamkhorana.com/static-site-generators/compare/mkdocs-vs-sphinx/) — MkDocs wins for new prose-first projects; Material-for-MkDocs in maintenance mode, Zensical successor incoming; **HIGH for choice, MEDIUM for long-term Material viability**
+- [Docker multi-arch GHA best practice](https://docs.docker.com/build/ci/github-actions/multi-platform/) and [Blacksmith ARM64 builds](https://www.blacksmith.sh/blog/building-multi-platform-docker-images-for-arm64-in-github-actions) — native-runner-per-arch + `buildx imagetools create` is 2026 SOTA; QEMU is the fallback; **HIGH**
+- [Helm OCI registries 2026](https://helm.sh/docs/topics/registries/) — OCI stable since 3.8, default-on; **HIGH**
+- [release-please v4 with Python](https://github.com/googleapis/release-please/issues/1741) and [release-please action marketplace](https://github.com/googleapis/release-please-action) — `release-type: python`, `extra-files` regex bumper; **HIGH**
+- [boto3 EKS token generation patterns](https://github.com/boto/boto3/issues/2309) and [analogous.dev EKS auth](https://www.analogous.dev/blog/using-the-kubernetes-python-client-with-aws/) — STS-presign + EXEC plugin payload pattern is the documented `aws eks get-token` reproduction; **HIGH**
+
+---
+*Stack research for: CI-pipeline Docker container (Python) wrapping helm + AWS, distributed via Bitbucket Pipes Marketplace*
+*Researched: 2026-06-16*

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -1,0 +1,160 @@
+# Research Summary — aws-eks-helm-deploy v2.0
+
+**Domain:** Bitbucket Pipelines Pipe — Helm chart deployment to AWS EKS
+**Synthesized from:** STACK.md · FEATURES.md · ARCHITECTURE.md · PITFALLS.md
+**Date:** 2026-06-16
+**Confidence:** HIGH (all four research dimensions converged on the same conclusions for the load-bearing decisions)
+
+---
+
+## 1. The 60-second TL;DR
+
+v2.0 is **best-in-class by being first to ship supply-chain modernization in the Bitbucket Pipe ecosystem**, not by adding more deployment knobs. The Atlassian baseline has neither OIDC nor Helm support; no Pipe ships a Cosign-signed image with SBOM. By dropping `awscli` in favor of pure `boto3`, the cold-start budget goes from ~25 s to a defensible sub-10 s — a marketing claim no competitor currently makes. The three load-bearing architectural decisions are: **(a)** a `Protocol`-based `AuthStrategy` with `AssumeRoleStrategy` as a composable decorator (so OIDC + role-assume is free), **(b)** a `ChartSource` Protocol mirroring auth (local / repo / OCI as orthogonal strategies), **(c)** a `helm/` module that only sees a `KUBECONFIG` env var, never auth or chart-source state.
+
+The three highest-blast-radius pitfalls are **(1)** under-constrained Bitbucket OIDC trust policies (consumer-side IAM mistake, our doc problem), **(2)** the `INJECT_BITBUCKET_METADATA: false` default flip silently breaking v1 consumers, and **(3)** multi-arch QEMU producing broken arm64 images that are invisible from Bitbucket's amd64-only runners.
+
+---
+
+## 2. Decision Sheet
+
+The chosen tool + version + one-line "why" for every slot the roadmap needs to fill. All HIGH confidence unless noted.
+
+### Language & runtime
+
+| Slot | Choice | Version | Why |
+|------|--------|---------|-----|
+| Python version | CPython | 3.13 | EOL 2029-10; PEP-695 generic syntax; supported by `boto3`, `mypy`, `ruff`. |
+| Base image | `python:3.13-slim-bookworm` | latest digest | **NOT alpine** — musl-libc breaks `boto3` wheel availability and slows builds. |
+| Package manager + env | `uv` | 0.11.x | Single Rust binary, 10–100× faster than Poetry, PEP-751-compatible `uv.lock`. |
+| Dependency resolution | `uv lock` + `uv sync --frozen --no-dev` | — | Reproducible Docker builds without dev tooling. |
+
+### Code quality
+
+| Slot | Choice | Version | Why |
+|------|--------|---------|-----|
+| Lint + format + import-sort + security | `ruff` | 0.15.x | Single binary replaces `black + isort + flake8 + pyupgrade + pydocstyle + bandit`. |
+| Type checker | `mypy --strict` | ~=1.18 | mypyc-compiled (now ≈ pyright speed); strongest `boto3-stubs` ecosystem. |
+| Type-check escape hatch | `basedpyright` | latest | Reserved for narrow corners where mypy is wrong. |
+| Pre-commit | `pre-commit` | ≥4.0 | Same checks locally + CI. |
+
+### Tests
+
+| Slot | Choice | Version | Why |
+|------|--------|---------|-----|
+| Runner | `pytest` | ≥8.4 | Standard. |
+| Coverage | `pytest-cov` + `coverage[toml]` | latest | Line + branch coverage; integrate into `pyproject.toml`. |
+| AWS mocks | `moto` | ≥5.0 | Drop-in `boto3` stub for unit tests. |
+| Kubernetes integration | `kind` | ≥0.29 | Lightest local-cluster runner. `k3d` rejected: extra Rancher dependency. |
+| Acceptance | existing Docker-image-spawn pattern, ported to GitHub Actions | — | Real `bitbucket-pipes-toolkit` runtime exercised via the image itself. |
+| Snapshot | `syrupy` | latest | For Helm-argv generation tests. |
+
+### Supply chain & release
+
+| Slot | Choice | Version | Why |
+|------|--------|---------|-----|
+| Release automation | `release-please` (GitHub Action `googleapis/release-please-action@v4`) | v4 | PR-based release (matches "no direct push to main"); `release-type: python` + `extra-files` updates `pipe.yml` image tag atomically with `pyproject.toml`. **Rejects `python-semantic-release`** (pushes to `main` directly). |
+| Image registry, primary | GHCR (`ghcr.io/yves-vogl/aws-eks-helm-deploy`) | — | Primary publish target; Cosign keyless integrates natively. |
+| Image registry, secondary | Docker Hub (`yvogl/aws-eks-helm-deploy`) | — | Preserves the v1.x discovery path for existing consumers and the Bitbucket Pipe Marketplace expectation. |
+| Image signing | `cosign sign` | 2.4 | **Keyless** via GitHub OIDC → Fulcio → Rekor. Zero key management. |
+| SBOM | `syft` | 1.42 | Emit **both** SPDX and CycloneDX; attach as Cosign attestations. |
+| Vuln scan | `trivy` | 0.59 | **Beats Grype** — covers image + Dockerfile + Helm chart + secret-leak in one binary; mitigate noise via `.trivyignore`. |
+| Python dep audit | `pip-audit` | latest | Gates on PyPI advisory DB. |
+| Provenance | `actions/attest-build-provenance@v1` | v1 | SLSA provenance attestation. |
+| Dependency bot | Dependabot | — | Python + Docker + GH Actions; auto-merge when CI green (incl. major bumps, per maintainer policy). |
+
+### AWS + Helm
+
+| Slot | Choice | Version | Why |
+|------|--------|---------|-----|
+| AWS SDK | `boto3` only | ~=1.40 | **Drop `awscli` entirely** — saves ~120 MB, kills the fragile `awscli.customizations.eks.get_token` internal import. The pre-signed-STS-URL → `k8s-aws-v1.` token can be implemented in ~40 lines of `boto3` + base64url. |
+| Helm | binary, copied multi-stage from `alpine/helm:3.18` | 3.18 | Active Helm release at v2.0 cut. |
+| `helm-diff` plugin | bundled in the image | 3.10 | Required for `DRY_RUN` and for the **D-1 PR-comment differentiator**. |
+| Pydantic settings | `pydantic-settings` | ≥2.5 | Single source of truth for the env-var schema; replaces hand-rolled validation. |
+
+### Multi-arch build
+
+| Slot | Choice | Version | Why |
+|------|--------|---------|-----|
+| Builder | `docker buildx` with **native runners per arch** | — | `ubuntu-24.04` for amd64 + `ubuntu-24.04-arm` for arm64 in a matrix; merge to one manifest. **QEMU rejected** — silently produces broken arm64 (Pitfall #5). |
+| Build cache | GHA cache backend | — | `type=gha,mode=max`. |
+
+### Documentation
+
+| Slot | Choice | Version | Why |
+|------|--------|---------|-----|
+| Docs site | `mkdocs-material` + `mike` (versioned) | 9.5 + latest | Mike provides `/v1/` and `/v2/` URL spaces side-by-side; required for the v1→v2 migration guide. |
+| Hosting | GitHub Pages | — | Free, owned by GitHub, no extra infra. |
+| Future migration target | `Zensical` | TBD | **MEDIUM confidence** — `mkdocs-material` entered maintenance mode early 2026; track as v2.1+ migration. |
+
+---
+
+## 3. Top 3 Differentiators (advertise these)
+
+1. **First Bitbucket Pipe with Cosign-signed image + SBOM + SLSA provenance.** No Pipe in the marketplace ships this as of mid-2026. The work is already in scope for v2.0; the marketing claim is free.
+2. **Sub-10-second cold start.** Documented benchmark in README. Achieved by dropping the full `awscli` package and using `python:3.13-slim` over `python:3-alpine`. No competitor advertises cold-start time today.
+3. **Helm-diff posted as a Bitbucket PR comment in `DRY_RUN` mode.** Genuinely novel in the Pipe ecosystem; `BITBUCKET_TOKEN` is auto-provided in Pipelines so the consumer needs no secret config. **Hard prerequisite:** the log-masking work (TS-9) must land first or this becomes a credential-leak vector (`helm get manifest` prints rendered `Secret` blocks in plaintext).
+
+---
+
+## 4. Top 5 Pitfalls (highest blast radius)
+
+1. **Bitbucket OIDC trust policy under-constrained.** Permissive `aud`/`sub` templates allow any Bitbucket workspace to assume the role. **Mitigation:** ship a documented IAM trust-policy template scoped to `BITBUCKET_WORKSPACE_UUID` + repo UUID; provide a `terraform`/`cdk` snippet. **Phase:** OIDC implementation.
+2. **`INJECT_BITBUCKET_METADATA: false` default flip silently breaks v1 consumers.** Charts referencing `.Values.bitbucket.*` template-fail at deploy time. **Mitigation:** detect prior-revision dependency in the new image; warn loudly on first-run; pin Docker Hub `:latest` to v1.3.0 forever, document `:2` rolling tag for opt-in. **Phase:** Migration guide + the metadata feature itself.
+3. **Helm `--atomic`/`--wait` + rollback + `HISTORY_MAX` coupling.** A `--wait`-less previous revision breaks rollback to it; `HISTORY_MAX` pruning compounds the failure mode. Worst case: production traffic on a half-deployed release. **Mitigation:** single `SAFE_UPGRADE` flag couples `--wait` + `--atomic`; rollback runs a pre-flight `helm history` check. **Phase:** Rollback subcommand + #17 (ship together).
+4. **Cosign keyless — three coupled failure modes:** dropped `id-token: write` permission (job-level inheritance), Rekor unavailable at verify time (no offline bundle), Fulcio cert expiry mid-job. **Mitigation:** workflow-level `permissions: id-token: write`, always `cosign sign --bundle`, separate short-lived signing job, verify-in-CI on every PR. **Phase:** Supply-chain modernization.
+5. **Multi-arch QEMU silently produces broken arm64.** Invisible from amd64-only Bitbucket runners; explodes on Apple Silicon developers and EKS Graviton nodes. **Mitigation:** native ARM runner matrix on GitHub Actions; `docker buildx imagetools inspect` smoke-test post-build; base image pinned by digest. **Phase:** Multi-arch image build + GHA release.
+
+---
+
+## 5. Cross-file conflicts & resolutions
+
+| Conflict | Resolution | Rationale |
+|----------|------------|-----------|
+| STACK recommends `python:3.13-slim-bookworm` (Debian), legacy Pipe uses `python:3-alpine`. | **Adopt Debian-slim.** | Eliminates musl-libc + `boto3` wheel quirks; image size delta is acceptable for the auth/cold-start wins. |
+| FEATURES proposes the PR-comment `helm-diff` differentiator (D-1); PITFALLS flags Helm output as a credential-leak vector (TS-9). | **Build D-1 only after the log-masking subsystem ships.** | Reordering moves the log-masking work to a precondition phase, not a follow-up. |
+| ARCHITECTURE proposes 10-phase build order; FEATURES sizes most table-stakes as S/M with explicit dependencies. | **Phase plan follows ARCHITECTURE's order; FEATURES sizing seeds per-phase plan creation.** | Single source of truth for build sequence is the dependency graph. |
+| STACK rates `mkdocs-material` MEDIUM confidence (maintenance mode). | **Use `mkdocs-material` for v2.0; track `Zensical` as v2.1+ migration target.** | 12–18 month horizon is sufficient; migration premature now. |
+| Existing v1.x bundles full `awscli`; STACK + FEATURES both recommend dropping it. | **Drop `awscli` entirely in v2.0.** | Frees ~120 MB, removes fragile internal-import path, enables sub-10 s cold-start claim. Documented in migration guide. |
+
+---
+
+## 6. Phase-sequencing implications
+
+The research files together imply a non-negotiable ordering for v2.0:
+
+1. **Project & toolchain bootstrap** — `pyproject.toml`, `uv`, `ruff`, `mypy`, `pytest`, repo restructure to `src/aws_eks_helm_deploy/...`, pre-commit. Nothing else can start until lint + types + tests are green on the existing v1.x logic.
+2. **Auth strategy abstraction (no behavior change)** — extract `AuthStrategy` Protocol from current code, port static-keys + assume-role behind it. Pure refactor. Unblocks OIDC as an additive strategy.
+3. **`boto3`-only EKS token generation** — replace `awscli.customizations.eks.get_token` with ~40-line `boto3` implementation. Unit-test with `moto`.
+4. **Chart source abstraction (no behavior change)** — extract `ChartSource` Protocol; port local-path behind it. Unblocks OCI + repo as additive strategies.
+5. **Bitbucket OIDC strategy** — adds `OidcWebIdentityStrategy`; includes the IAM trust-policy template + documented `aud`/`sub` constraints. **(Pitfall #1.)**
+6. **OCI + repo chart sources** — adds `OciChartSource`, `RepoChartSource` + `CHART_VERSION`, `REPO_URL` vars.
+7. **Log masking subsystem** — must land before D-1. Redacts `kind: Secret` payloads from any Helm output the pipe emits. **(Differentiator #3 precondition.)**
+8. **Dry-run + helm-diff bundling + PR-comment poster** — `ACTION=diff` or `DRY_RUN=true`. **(Differentiator #3.)**
+9. **Rollback subcommand** — `ACTION=rollback` + `REVISION` + `HISTORY_MAX` via `--history-max`. Ships with the `SAFE_UPGRADE` flag. **(Pitfall #3 + closes #17.)**
+10. **Opt-in metadata injection** — flip the default; ship loud warning when v1 chart references detected. **(Pitfall #2 + closes #16.)**
+11. **Multi-stage multi-arch image + Cosign + SBOM + Trivy + pip-audit** — GitHub Actions release pipeline. Native ARM runners, no QEMU. **(Differentiator #1 + Pitfall #4, #5.)**
+12. **Documentation site** — `mkdocs-material` + `mike`, v1.x and v2 spaces side-by-side, migration guide is the headline page.
+13. **Bitbucket-side discovery pipeline (mirror-only)** — minimal `bitbucket-pipelines.yml` that re-publishes the marketplace listing; no release responsibilities.
+
+Phases 5/6, 8/9, 10 can be parallelized once 1–4 land.
+
+---
+
+## 7. Confidence calibration
+
+- **HIGH:** every tool choice in §2, every differentiator in §3, pitfalls 1–3 and 5 in §4, all conflict resolutions in §5.
+- **MEDIUM:** `mkdocs-material` choice (12–18 month horizon only), Cosign-keyless pitfall #4 (depends on Sigstore stability through 2026).
+- **LOW:** none — every load-bearing decision is HIGH; the research convergence is unusually strong because the project scope is well-bounded.
+
+---
+
+## 8. Source attribution
+
+Detailed analysis, citations, and full tables live in the four sibling files:
+
+- [`STACK.md`](STACK.md) — concrete tool versions + anti-recommendations
+- [`FEATURES.md`](FEATURES.md) — table-stakes / differentiators / anti-features with sizing + dependencies
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — full `src/` layout, component graph, test pyramid, Dockerfile shape
+- [`PITFALLS.md`](PITFALLS.md) — 13 pitfalls with warning signs + prevention + phase mapping + external sources
+
+This SUMMARY.md is the decision sheet; the four files are the evidence.


### PR DESCRIPTION
## Summary

Bootstrap the `.planning/` directory with the full GSD project context for the v2.0 modernization workstream — no code changes, no impact on the v1.3.0 line, no Docker image rebuild. This PR is the planning artefact that drives all subsequent v2.0 phase work.

## What's in `.planning/`

```
.planning/
├── PROJECT.md          v2.0 context: core value, validated v1 reqs, active v2 scope, out-of-scope with rationale, key decisions
├── REQUIREMENTS.md     67 v1 REQ-IDs across 13 categories, traceability table populated
├── ROADMAP.md          7-phase plan, 67/67 requirement coverage, success criteria + risks per phase
├── STATE.md            initial position at Phase 1, deferred items registry
├── config.json         YOLO mode, standard granularity, balanced model profile, research/plan-check/verifier/nyquist/drift-guard on
└── research/
    ├── STACK.md        concrete tool + version decisions for the 2026 toolchain
    ├── FEATURES.md     14 table stakes, 7 differentiators, 9 anti-features
    ├── ARCHITECTURE.md full src/ layout, Protocol-based auth + chart sources, test pyramid
    ├── PITFALLS.md     13 pitfalls with prevention strategies + phase mapping
    └── SUMMARY.md      decision sheet, top 3 differentiators, top 5 pitfalls, conflict resolutions
```

## Scope decisions captured (interview phase)

1. **Primary forge: GitHub.** Bitbucket is reduced to read-only mirror + Pipe Marketplace publishing.
2. **v2.0 is a clean break.** v1.3.0 image stays on Docker Hub forever pinned at `:latest` and `:1.3.0`; a new `:2` rolling tag is introduced for v2 consumers.
3. **New features in v2.0:** AWS OIDC/IRSA (closes #3), OCI + Helm repo chart sources (closes #7), dry-run with helm-diff PR comments, rollback with SAFE_UPGRADE, `--history-max` (closes #17), opt-in Bitbucket metadata (closes #16, breaking).

## Phase plan (7 phases, 67/67 REQs)

| # | Phase | REQs |
|---|-------|------|
| 1 | Toolchain & Spine | 14 (TOOL-01..08, IMAGE-01,02,03,05, OBS-01,02) |
| 2 | AWS Layer & Auth Foundation | 3 (AUTH-01, AUTH-02, AUTH-07) |
| 3 | Helm Core & Upgrade Action — closes #17 | 7 (CHART-01, CHART-05, PIPE-01, PIPE-06, HISTORY-01,02, META-01) |
| 4 | OIDC & Chart Source Extensions — closes #3, #7 | 7 (AUTH-03..06, CHART-02..04) |
| 5 | Log Masking, Diff, Rollback & Metadata Flip — closes #16 | 8 (SEC-06, PIPE-02..05, META-02,03, MIG-02) |
| 6 | Release Pipeline & Supply Chain | 19 (IMAGE-04,06, SEC-01..05, CI-01..07, CMN-01..04, MIG-01) |
| 7 | Documentation Site & Migration Guide | 9 (DOC-01..08, MIG-03) |

## Stack decisions (HIGH confidence)

- `uv` 0.11.x for env/dep/lock; `ruff` 0.15.x for lint+format; `mypy --strict` ~=1.18; `pytest` + `pytest-cov` (100% target); `kind` for K8s integration; `moto` for AWS mocking
- `python:3.13-slim-bookworm` (NOT alpine); Helm 3.18 + `helm-diff` 3.10; **drop `awscli` entirely** in favor of `boto3` (~120 MB image size win + kills the fragile internal import)
- `release-please` v4 (rejects `python-semantic-release` because it pushes directly to `main`); publish to both `ghcr.io/yves-vogl/aws-eks-helm-deploy` and `docker.io/yvogl/aws-eks-helm-deploy`
- Supply chain: Cosign 2.4 keyless, Syft 1.42 (SPDX + CycloneDX), Trivy 0.59, `actions/attest-build-provenance@v1`
- Multi-arch: native `ubuntu-24.04-arm` runners (QEMU rejected — silently produces broken arm64)
- Docs: `mkdocs-material` 9.5 + `mike` for versioned `/v1/` and `/v2/` URL spaces

## Architectural decisions captured

- Protocol-based `AuthStrategy` with `AssumeRoleStrategy` as a composable decorator → OIDC + role-assume is free when OIDC lands
- `ChartSource` Protocol mirrors auth → adding repo + OCI is purely additive
- `helm/` module sees only a `KUBECONFIG` env var — auth- and chart-source-agnostic; this boundary is what made OIDC un-shippable in v1

## Top pitfalls flagged

1. Under-constrained Bitbucket OIDC trust policies (consumer-side IAM mistake, our docs problem) — IAM trust-policy template scoped to `BITBUCKET_WORKSPACE_UUID` + repo UUID ships with v2.0
2. `INJECT_BITBUCKET_METADATA: false` default silently breaks v1 consumers — detect prior-revision dependency, warn loudly, `:latest` frozen at v1.3.0 forever
3. Multi-arch QEMU silently broken arm64 — native ARM runners only
4. Cosign keyless triple-coupled failure modes — workflow-level `id-token: write`, always sign with `--bundle`, separate signing job, verify-in-CI

## Commits

1. `1d1f729` — PROJECT.md + config.json
2. `4f7500e` — research/STACK + FEATURES + ARCHITECTURE + PITFALLS + SUMMARY
3. `8821148` — REQUIREMENTS.md (67 REQs)
4. `60c4869` — ROADMAP.md + STATE.md + REQUIREMENTS.md traceability + .gitignore
5. `687f880` — STATE.md REQ count correction (57 → 67)

All commits GPG-signed.

## Test plan

- [ ] Confirm `.planning/PROJECT.md` "Active" requirements match the scope chosen during the interview phase (GitHub primary, clean break, OIDC + OCI + dry-run + rollback + history-max + opt-in metadata)
- [ ] Confirm `.planning/REQUIREMENTS.md` Traceability table maps every v1 REQ to exactly one phase (no `TBD` left)
- [ ] Confirm `.planning/ROADMAP.md` phase order respects the SUMMARY.md §6 sequencing constraints (Toolchain first, AuthStrategy before OIDC, ChartSource before OCI, SEC-06 log-mask before PIPE-03 PR-comment)
- [ ] Confirm no `.planning/` file references invented APIs or env vars not in PROJECT.md / REQUIREMENTS.md
- [ ] No code changes — no CI required beyond planning-doc spot-checks

## Next step after merge

`/gsd-plan-phase 1` (Toolchain & Spine).