### PR TITLE
plan(02): research + 4 plans + validation for AWS Layer & Auth Foundation

### DIFF
--- a/.planning/phases/02-aws-layer-auth-foundation/02-01-PLAN.md
+++ b/.planning/phases/02-aws-layer-auth-foundation/02-01-PLAN.md
@@ -1,0 +1,392 @@
+---
+phase: 02-aws-layer-auth-foundation
+plan: 1
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/aws_eks_helm_deploy/aws/__init__.py
+  - src/aws_eks_helm_deploy/aws/eks_token.py
+  - src/aws_eks_helm_deploy/errors.py
+  - tests/unit/test_eks_token.py
+autonomous: true
+requirements:
+  - AUTH-07
+tags:
+  - aws
+  - boto3
+  - eks
+  - sts
+  - token
+  - presigned-url
+
+must_haves:
+  truths:
+    - "`from aws_eks_helm_deploy.aws.eks_token import generate_eks_token` resolves to a callable with signature `(session: boto3.session.Session, cluster_name: str, region: str) -> str`."
+    - "`generate_eks_token(session, 'my-cluster', 'eu-central-1')` returns a string that starts with the literal prefix `k8s-aws-v1.`."
+    - "The returned token contains no `=` padding characters (base64url-no-padding per upstream awscli + aws-iam-authenticator spec)."
+    - "Base64url-decoding the token payload yields a valid presigned STS GetCallerIdentity URL whose query string contains `Action=GetCallerIdentity`, `X-Amz-Expires=60`, `X-Amz-Algorithm=AWS4-HMAC-SHA256`, and `X-Amz-SignedHeaders` listing both `host` and `x-k8s-aws-id`."
+    - "The decoded URL hostname is `sts.{region}.amazonaws.com` (regional endpoint) and is NEVER the global `sts.amazonaws.com` endpoint."
+    - "Changing `cluster_name` between two calls with the same credentials produces two different tokens (the cluster name is signed into the URL via `x-k8s-aws-id`)."
+    - "Changing `region` between two calls changes the endpoint hostname in the decoded URL."
+    - "`EksTokenError` exists in `aws_eks_helm_deploy.errors` as a `PipeError` subclass with `exit_code = 3` (matches ClusterAccessError tier — EKS reach failure)."
+    - "The module imports cleanly: `mypy --strict src/aws_eks_helm_deploy/aws/eks_token.py` exits 0."
+    - "`uv run pytest -m unit -q tests/unit/test_eks_token.py` exits 0 with 100% line+branch coverage on `src/aws_eks_helm_deploy/aws/eks_token.py`."
+  artifacts:
+    - path: "src/aws_eks_helm_deploy/aws/__init__.py"
+      provides: "Empty namespace marker for the `aws` subpackage."
+      contains: "from __future__ import annotations"
+    - path: "src/aws_eks_helm_deploy/aws/eks_token.py"
+      provides: "Pure boto3 EKS bearer token generator — no awscli import. Replicates the awscli STSClientFactory + TokenGenerator algorithm via botocore event injection."
+      contains: "def generate_eks_token"
+      min_lines: 50
+    - path: "src/aws_eks_helm_deploy/errors.py"
+      provides: "Adds `EksTokenError` subclass for token-generation failures (exit code 3)."
+      contains: "class EksTokenError"
+    - path: "tests/unit/test_eks_token.py"
+      provides: "Structural-equivalence test suite for `generate_eks_token` under `@mock_aws`."
+      contains: "from moto import mock_aws"
+      min_lines: 120
+  key_links:
+    - from: "src/aws_eks_helm_deploy/aws/eks_token.py"
+      to: "boto3 STS client event system"
+      via: "session.client('sts').meta.events.register('provide-client-params.sts.GetCallerIdentity', ...)"
+      pattern: "meta\\.events\\.register"
+    - from: "src/aws_eks_helm_deploy/aws/eks_token.py"
+      to: "regional STS endpoint"
+      via: "session.client('sts', endpoint_url=f'https://sts.{region}.amazonaws.com')"
+      pattern: "endpoint_url=f.https://sts\\."
+    - from: "src/aws_eks_helm_deploy/aws/eks_token.py"
+      to: "errors.EksTokenError"
+      via: "raise EksTokenError on botocore.exceptions.ClientError"
+      pattern: "raise EksTokenError"
+    - from: "tests/unit/test_eks_token.py"
+      to: "moto"
+      via: "from moto import mock_aws; @mock_aws"
+      pattern: "@mock_aws"
+---
+
+<objective>
+Ship the pure-`boto3` EKS bearer token generator that replaces v1's `from awscli.customizations.eks.get_token import STSClientFactory, TokenGenerator` internal import. After this plan, `aws_eks_helm_deploy.aws.eks_token.generate_eks_token(session, cluster_name, region)` produces a structurally correct `k8s-aws-v1.<base64url-no-padding(presigned-STS-GetCallerIdentity-URL)>` token using only `boto3` (1.43.x already in `pyproject.toml`), with the `x-k8s-aws-id` cluster header signed into the presigned URL via botocore's event emitter.
+
+Purpose: Closes AUTH-07 (pure-boto3 EKS token, no awscli). The token generator is the leaf node of Phase 2's DAG — it has no other in-phase dependencies (the future auth strategies in Plans 02-02..04 consume `AwsCredentials` to build a session, then call this function). Shipping this first lets the other plans run in parallel without blocking.
+
+Output:
+- `src/aws_eks_helm_deploy/aws/` subpackage (new) with empty `__init__.py` and `eks_token.py`.
+- `errors.py` extended with `EksTokenError(PipeError)` — exit code 3 (same tier as `ClusterAccessError`; the EKS authentication flow lives in the same reach surface as the cluster reach itself).
+- `tests/unit/test_eks_token.py` — full structural-equivalence test suite under `@mock_aws`, 100% line+branch on `eks_token.py`.
+- ROADMAP Phase 2 SC2 deviation documented in this plan's `<deviations>` block (byte-equal golden test is structurally impossible — replaced with structural equivalence per RESEARCH Section A).
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md
+@src/aws_eks_helm_deploy/errors.py
+@src/aws_eks_helm_deploy/settings.py
+@pyproject.toml
+@tests/unit/test_settings.py
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 02-1-01: Add EksTokenError to errors.py + aws/ package skeleton</name>
+  <files>src/aws_eks_helm_deploy/errors.py, src/aws_eks_helm_deploy/aws/__init__.py</files>
+  <read_first>
+    - src/aws_eks_helm_deploy/errors.py (existing PipeError hierarchy — exit codes 1..6 already taken; new EksTokenError must be a documented addition, NOT renumber existing exits)
+    - .planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md (Section C: error handling pattern; Section I: STRIDE row T-`02`-`01` on credential disclosure)
+    - .planning/phases/01-toolchain-spine/01-01-PLAN.md (Plan A — for the established error-class shape: class docstring, `exit_code: int` class attribute, no custom `__init__`)
+  </read_first>
+  <behavior>
+    - `from aws_eks_helm_deploy.errors import EksTokenError` succeeds.
+    - `EksTokenError("x").exit_code == 3` (same tier as `ClusterAccessError` since failing to mint an EKS token is structurally an EKS-reach failure surfaced to the consumer the same way).
+    - `isinstance(EksTokenError("x"), PipeError) is True` (caught by `cli.main()`'s typed handler).
+    - `EksTokenError("x", exit_code=42).exit_code == 42` (custom-exit-code constructor argument is inherited from `PipeError.__init__`).
+    - `from aws_eks_helm_deploy.aws import __name__` resolves (package importable).
+    - Existing exit codes 1..6 are UNCHANGED; only ADDING `EksTokenError` to the hierarchy.
+    - `uv run mypy --strict src` still exits 0 (no regression).
+    - `uv run pytest -m unit -q tests/unit/test_errors.py` still passes (Plan 01 tests don't reference `EksTokenError`, so they continue to pass; new tests for `EksTokenError` are added in this task).
+  </behavior>
+  <action>
+    Edit `src/aws_eks_helm_deploy/errors.py`:
+    - Extend the exit-code reference docstring at the top of the file to list the new entry: `7  — EksTokenError` (use the next free integer; existing codes are 1..6).
+    - WAIT — re-read the existing file: ClusterAccessError=3 is "EKS describe-cluster failed", which is the same logical tier as "EKS token mint failed". The cleanest mapping per RESEARCH Section C "AuthenticationError maps to exit code 2" is to reuse `exit_code = 3` for `EksTokenError` (it IS an EKS-side failure). HOWEVER, observability is clearer if the two errors carry distinct codes. Decision: use `exit_code = 3` (alignment with the EKS-reach tier — ClusterAccessError and EksTokenError both represent "we contacted EKS / STS and the round-trip failed"); add a docstring note that the two SHARE exit code 3 deliberately because they are surfaced to consumers identically.
+    - Append a new class at the end:
+      ```
+      class EksTokenError(PipeError):
+          """EKS bearer-token generation via boto3 failed. Exit code 3 (shared with ClusterAccessError)."""
+          exit_code = 3
+      ```
+    - Do NOT touch the existing exit-code reference in the file header beyond adding the new class entry (e.g., "3  — ClusterAccessError / EksTokenError"). Keep the existing seven classes and their exit codes byte-stable.
+
+    Create `src/aws_eks_helm_deploy/aws/__init__.py`:
+    - Single line: `"""AWS-layer subpackage (boto3 STS / EKS calls)."""` (docstring only — no re-exports yet; Plan 02-04 may add a public surface).
+    - Add `from __future__ import annotations` on the next line to satisfy ruff `I001` consistency with the rest of `src/`.
+
+    Add unit test for `EksTokenError` to `tests/unit/test_errors.py` (extending the existing file — do NOT create a new test file):
+    - `test_eks_token_error_exit_code` — `EksTokenError("x").exit_code == 3` and `isinstance(EksTokenError("x"), PipeError) is True`.
+    - `test_eks_token_error_custom_exit_code` — `EksTokenError("x", exit_code=42).exit_code == 42`.
+
+    Verify `uv run ruff check src tests && uv run mypy --strict src && uv run pytest -m unit -q tests/unit/test_errors.py` exits 0 before moving to Task 02-1-02.
+
+    Per D-AWS-07 (see RESEARCH Section A): this task lays the error type that `eks_token.py` will raise in Task 02-1-02 — the two tasks are tightly coupled but split so `errors.py` lands cleanly in its own commit.
+  </action>
+  <verify>
+    <automated>uv run ruff check src tests &amp;&amp; uv run mypy --strict src &amp;&amp; uv run pytest -m unit -q tests/unit/test_errors.py --no-cov</automated>
+  </verify>
+  <done>
+    `EksTokenError` is importable, has `exit_code == 3`, is a `PipeError` subclass; `aws/__init__.py` exists and is importable; existing 7-class error hierarchy is byte-stable; ruff + mypy still green; the existing `test_errors.py` tests plus the two new `EksTokenError` tests all pass.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 02-1-02: generate_eks_token() — pure boto3 token generator with botocore event injection</name>
+  <files>src/aws_eks_helm_deploy/aws/eks_token.py, tests/unit/test_eks_token.py</files>
+  <read_first>
+    - .planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md (Section A — full code pattern verified in project venv, all constants, X-Amz-SignedHeaders requirements, common pitfalls table; Section C — regional STS endpoint enforcement, ClientError → typed error mapping; Section G — test strategy under @mock_aws)
+    - src/aws_eks_helm_deploy/errors.py (after Task 02-1-01 commit — confirm EksTokenError available)
+    - tests/unit/test_settings.py (test style: `from __future__ import annotations`, `@pytest.mark.unit` decorator, monkeypatch usage)
+    - pyproject.toml (confirms boto3 ~= 1.43, moto[eks,sts] ~= 5.2, boto3-stubs[eks,sts] all already installed — NO new packages to add)
+  </read_first>
+  <behavior>
+    Module `src/aws_eks_helm_deploy/aws/eks_token.py` exposes:
+    - Module-level constants (UPPERCASE):
+      - `TOKEN_PREFIX: Final[str] = "k8s-aws-v1."` (matches awscli + aws-iam-authenticator)
+      - `K8S_AWS_ID_HEADER: Final[str] = "x-k8s-aws-id"` (cluster ID header signed into the URL)
+      - `URL_TIMEOUT: Final[int] = 60` (X-Amz-Expires=60 — hardcoded per upstream)
+    - Public function `generate_eks_token(session: boto3.session.Session, cluster_name: str, region: str) -> str` with full docstring (per `[tool.ruff.lint] ANN` rules — annotate all parameters and return).
+    - The function:
+      1. Constructs an STS client from the supplied session with `endpoint_url=f"https://sts.{region}.amazonaws.com"` AND `config=botocore.config.Config(retries={"max_attempts": 3, "mode": "standard"})`.
+      2. Registers TWO botocore events on the STS client (per RESEARCH Section A verified pattern):
+         - `provide-client-params.sts.GetCallerIdentity` — extracts the `x-k8s-aws-id` value from `Params` and stores it in a closure dict (because passing the header in Params would otherwise raise `ParamValidationError`).
+         - `before-sign.sts.GetCallerIdentity` — injects the stored header into the request before SigV4 signing so it appears in `X-Amz-SignedHeaders=host;x-k8s-aws-id`.
+      3. Calls `sts.generate_presigned_url("get_caller_identity", Params={K8S_AWS_ID_HEADER: cluster_name}, ExpiresIn=URL_TIMEOUT, HttpMethod="GET")`.
+      4. Encodes the URL via `base64.urlsafe_b64encode(url.encode("utf-8")).decode("utf-8").rstrip("=")` and returns `TOKEN_PREFIX + encoded`.
+    - On `botocore.exceptions.ClientError`, raises `EksTokenError(f"EKS token generation failed [{code}]: {message}") from exc` (typed handover to `cli.main()`).
+    - On `botocore.exceptions.NoCredentialsError`, raises `EksTokenError("No AWS credentials available for EKS token generation") from exc` (defensive — `generate_presigned_url` could surface this if the session is misconfigured upstream).
+    - Mypy-strict: full type annotations on the two event-handler closures, no `# type: ignore` except a single one on `request.headers[K8S_AWS_ID_HEADER] = ...` IF needed (botocore typing for the `before-sign` event is permissive — accepted per RESEARCH Section A). Type-ignore must carry a comment explaining WHY.
+
+    Test file `tests/unit/test_eks_token.py` covers (under `@mock_aws`):
+    - `test_token_starts_with_v1_prefix` — `token.startswith("k8s-aws-v1.")`.
+    - `test_token_contains_no_base64_padding` — `"=" not in token`.
+    - `test_decoded_url_has_x_amz_expires_60` — decode payload → `X-Amz-Expires` query param equals `"60"`.
+    - `test_decoded_url_signs_cluster_name_header` — decode payload → `"x-k8s-aws-id"` appears in the `X-Amz-SignedHeaders` query param value.
+    - `test_decoded_url_action_is_get_caller_identity` — decode payload → `Action=GetCallerIdentity`.
+    - `test_decoded_url_uses_regional_sts_endpoint` — decoded URL hostname is `sts.eu-central-1.amazonaws.com` (NOT `sts.amazonaws.com`).
+    - `test_different_cluster_names_produce_different_tokens` — `generate_eks_token(s, "cluster-a", region) != generate_eks_token(s, "cluster-b", region)` (different cluster names are signed into the URL).
+    - `test_different_regions_produce_different_endpoints` — call with `region="us-east-1"`, assert decoded URL hostname is `sts.us-east-1.amazonaws.com`.
+    - `test_algorithm_is_sigv4` — `X-Amz-Algorithm=AWS4-HMAC-SHA256` in the query.
+    - `test_client_error_raises_eks_token_error` — patch `sts.generate_presigned_url` (via `pytest-mock` mocker.patch.object on the boto3 client method) to raise `botocore.exceptions.ClientError({'Error': {'Code': 'X', 'Message': 'Y'}}, 'GetCallerIdentity')` and assert `EksTokenError` is raised with `exit_code == 3`. Use `mocker.patch` on the boto3 client method via `boto3.Session().client` factory return; OR construct the session normally under `@mock_aws` then monkeypatch the client's `generate_presigned_url` via `mocker.patch.object(sts_instance, 'generate_presigned_url', side_effect=...)`. Note in the test docstring why we can't use `@mock_aws`'s natural error injection here (moto doesn't easily simulate STS errors on this specific path).
+    - `test_no_credentials_error_raises_eks_token_error` — similar pattern, raise `botocore.exceptions.NoCredentialsError`, assert `EksTokenError`.
+
+    All tests under `@mock_aws` (single decorator, applies to the whole function) construct a `boto3.Session` with dummy credentials per RESEARCH Section G:
+    ```
+    session = boto3.Session(
+        region_name="eu-central-1",
+        aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    )
+    ```
+    Use `urllib.parse.urlparse` + `parse_qsl` to decode the URL (RESEARCH Section G has the exact decode helper — five lines).
+
+    Coverage target: 100% line + 100% branch on `src/aws_eks_helm_deploy/aws/eks_token.py` — including BOTH error branches (`ClientError` and `NoCredentialsError`).
+  </behavior>
+  <action>
+    Create `src/aws_eks_helm_deploy/aws/eks_token.py` per RESEARCH Section A verified code pattern (boto3 1.43.31 + botocore 1.43.31 already locked). Specifics:
+    - Module docstring referencing AUTH-07 in the traceability header (mirror the style of `settings.py` lines 1–15).
+    - `from __future__ import annotations` as the first non-docstring import.
+    - Imports: `base64`, `typing.Final`, `boto3`, `boto3.session`, `botocore.config`, `botocore.exceptions`, `from aws_eks_helm_deploy.errors import EksTokenError`.
+    - Constants block: `TOKEN_PREFIX`, `K8S_AWS_ID_HEADER`, `URL_TIMEOUT` (all `Final` per ruff `RUF012`).
+    - The `_retrieve_header` and `_inject_header` closures inside `generate_eks_token` (per RESEARCH Section A — closure-based dict is the cleanest pattern; alternatives like `nonlocal` are equivalent but the dict pattern matches what the awscli upstream does literally).
+    - Add a `try/except botocore.exceptions.ClientError as exc: raise EksTokenError(...) from exc` around the `generate_presigned_url` call (per RESEARCH Section C error-handling pattern). The `try` block should also catch `botocore.exceptions.NoCredentialsError` and raise `EksTokenError("No AWS credentials available for EKS token generation") from exc`.
+    - Public function signature must be exactly: `def generate_eks_token(session: boto3.session.Session, cluster_name: str, region: str) -> str:`.
+    - Type-ignore comments: only on lines where botocore typing genuinely lacks coverage (the `before-sign` event's `request` argument is typed as `Any` upstream); document each `# type: ignore[...]` with a brief comment per Phase 1 PATTERNS.md convention.
+    - Do NOT use `awscli.customizations.eks.get_token` — failure of an audit grep `grep -r 'awscli' src/` returning anything is a regression. Add a comment header noting "Pure-boto3 — does NOT import awscli; verified by grep gate in 02-VALIDATION.md".
+
+    Create `tests/unit/test_eks_token.py` per the behavior list:
+    - Module docstring: "Structural-equivalence test suite for generate_eks_token (AUTH-07). The ROADMAP's 'byte-equal' wording is replaced with structural equivalence per RESEARCH Section A — see 02-01-PLAN.md `<deviations>` for the documented departure."
+    - `from __future__ import annotations`
+    - imports: `base64`, `urllib.parse`, `pytest`, `boto3`, `botocore.exceptions`, `from moto import mock_aws`, `from aws_eks_helm_deploy.aws.eks_token import generate_eks_token, TOKEN_PREFIX, URL_TIMEOUT, K8S_AWS_ID_HEADER`, `from aws_eks_helm_deploy.errors import EksTokenError, PipeError`.
+    - Helper `_decode_token_payload(token: str) -> dict[str, str]` — strips the `k8s-aws-v1.` prefix, adds back `=` padding via `enc + "=" * (-len(enc) % 4)`, base64url-decodes, and returns the parsed query-string dict via `dict(urllib.parse.parse_qsl(urllib.parse.urlparse(url).query))`. Reuse this helper in every test that inspects the URL.
+    - Each test is `@pytest.mark.unit` and `@mock_aws` (decoration order: `@mock_aws` outermost, `@pytest.mark.unit` innermost — moto's mock context must wrap the boto3 calls).
+    - For the two error-path tests, use `pytest-mock`'s `mocker` fixture to patch `generate_presigned_url` on the STS client. Pattern: create the session, call `mocker.patch("botocore.client.BaseClient.generate_presigned_url", side_effect=...)`. Document this in the test docstring as the cleanest way to inject the specific exception under `@mock_aws`.
+    - Do NOT add a test for the "no awscli import" property — that gate lives in 02-VALIDATION.md as a `grep` audit (the test would not add unit-test value; a structural code-grep is the right check).
+
+    Verify 100% coverage explicitly: run `uv run pytest -m unit -q tests/unit/test_eks_token.py --cov=src/aws_eks_helm_deploy/aws/eks_token --cov-branch --cov-report=term-missing` and ensure no missed lines or branches. If the `NoCredentialsError` branch is uncovered, add an explicit test that triggers it.
+
+    Stub call-out: this function takes a pre-built `boto3.Session`. The session-construction logic (with `to_boto3_kwargs()` from `AwsCredentials`) lives in Plan 02-04 (`auth/__init__.py::select_strategy` wires it). This module is intentionally session-agnostic.
+  </action>
+  <verify>
+    <automated>uv run ruff check src tests &amp;&amp; uv run ruff format --check src tests &amp;&amp; uv run mypy --strict src &amp;&amp; uv run pytest -m unit -q tests/unit/test_eks_token.py --cov=aws_eks_helm_deploy.aws.eks_token --cov-branch --cov-fail-under=100 --no-header</automated>
+  </verify>
+  <done>
+    `generate_eks_token` is importable, returns a structurally valid `k8s-aws-v1.` token under `@mock_aws`, the test suite covers all behavior bullets, line+branch coverage on `eks_token.py` is 100%, the function uses ZERO `awscli` imports (grep audit deferred to 02-VALIDATION.md), `ruff` + `mypy --strict src` exit 0, and no regression in the existing 33+ Phase 1 unit tests.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| AWS credentials (in `boto3.Session`) → STS regional endpoint | SigV4 HMAC signing produces a presigned URL whose signature covers the cluster-ID header. Tampering with the URL or any signed header invalidates the signature; the kube-apiserver auth webhook rejects the token. |
+| `generate_presigned_url` → kube-apiserver auth webhook | The presigned URL is the bearer token. It is transmitted by kubectl/helm via TLS to the EKS control plane. We do not touch transit security — that is TLS owned by EKS. |
+| `EksTokenError` → `cli.main` → `pipe.fail()` | Error messages from boto3 contain operation names + STS error codes (`InvalidClientTokenId`, `ExpiredToken`, etc.). These are SAFE to surface — they do NOT contain credential values. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-01-01 | Tampering | Presigned URL in transit (MITM between consumer and EKS) | mitigate | SigV4 HMAC: the URL signature covers the `host` + `x-k8s-aws-id` headers. Any in-transit modification invalidates the signature and the cluster rejects the token. We rely on botocore's SigV4 implementation (no custom signing). |
+| T-02-01-02 | Information Disclosure | `EksTokenError` message surfaces to pipe stderr via `pipe.fail()` | mitigate | We catch `ClientError` and construct the error message from `exc.response["Error"]["Code"]` + `exc.response["Error"]["Message"]` — these are public STS error codes (e.g. `InvalidClientTokenId`). We do NOT include `exc.response["ResponseMetadata"]` (which has the request ID — informational only, but unnecessary). Credential values never appear in `botocore.exceptions.ClientError` messages by AWS-side design. |
+| T-02-01-03 | Tampering | Wrong STS endpoint (`sts.amazonaws.com` global instead of regional) | mitigate | `endpoint_url=f"https://sts.{region}.amazonaws.com"` is hardcoded in the function body — there is no code path that falls back to the global endpoint. RESEARCH Section A verified that omitting this produces tokens rejected by most EKS clusters. |
+| T-02-01-04 | Spoofing | `x-k8s-aws-id` header tampering before signing | mitigate | The two-event botocore pattern (`provide-client-params` extracts, `before-sign` injects) is the awscli-equivalent path; the header value is signed into the URL via `X-Amz-SignedHeaders=host;x-k8s-aws-id`. Tampering invalidates the SigV4 signature. |
+| T-02-01-05 | Denial of Service | Token-mint failure cascades into pipe failure | accept | One token-mint per pipe invocation. STS has 99.99% availability SLA. botocore's default retry (3 attempts, standard mode) handles transient failures; further retries would mask real problems. `EksTokenError` exit code 3 surfaces the failure to the consumer. |
+| T-02-01-SC | Tampering | Package legitimacy — `boto3`, `botocore`, `moto[eks,sts]` | mitigate | All three packages are in RESEARCH Section H `## Package Legitimacy Audit` with verdict OK (Amazon-owned for boto3/botocore; getmoto/moto for moto). All already installed and locked in `uv.lock` from Phase 1. NO new packages introduced in this plan. |
+</threat_model>
+
+<deviations>
+## Documented Deviations from ROADMAP / RESEARCH
+
+### Deviation 1: ROADMAP Phase 2 SC2 "byte-equal" wording is structurally impossible
+
+**ROADMAP claim:** "a golden unit test asserts the produced token equals `aws eks get-token` reference output byte-for-byte"
+
+**Reality (per RESEARCH Section A "Golden Test Strategy"):** The presigned URL contains `X-Amz-Date` (changes per invocation, ISO 8601 timestamp to the second) and an HMAC signature (changes with both timestamp and credentials). A byte-for-byte comparison would be ALWAYS-FLAKY because two consecutive calls — even with identical credentials, cluster name, and region — produce different timestamps and therefore different signatures.
+
+**Plan response:** Implement the test as **structural equivalence** instead — assert the seven structural properties enumerated in RESEARCH Section A "Golden Test Strategy":
+1. Starts with `k8s-aws-v1.`
+2. Base64url-decodes to a valid URL after `=` padding restoration
+3. `X-Amz-Expires=60`
+4. `x-k8s-aws-id` in `X-Amz-SignedHeaders`
+5. `Action=GetCallerIdentity`
+6. Hostname is `sts.{region}.amazonaws.com` (regional, NOT global)
+7. No `=` padding characters
+
+This is what the upstream `aws-iam-authenticator` Go reference suite does (`pkg/token/token_test.go`) — they assert structural properties, not byte equality.
+
+**Action item:** The plan-checker / phase-verifier MUST surface this deviation when comparing Phase 2 output against ROADMAP Phase 2 SC2. The deviation is intentional and matches industry practice; no code change required to "satisfy" the byte-equal wording. ROADMAP wording may be updated retroactively in Phase 7 documentation work.
+
+### Deviation 2: `EksTokenError` shares `exit_code=3` with `ClusterAccessError`
+
+**Decision:** `EksTokenError.exit_code = 3` (same tier as `ClusterAccessError`).
+
+**Rationale:** Both errors represent "we tried to interact with EKS (STS GetCallerIdentity → presign / EKS describe-cluster) and the round-trip failed". Consumers handling pipe exit codes care about reach failure as a category, not which AWS API specifically rejected. Adding a distinct exit code (7) would not give the consumer more actionable information — both errors require the same response: check credentials, check IAM permissions, check region/cluster name.
+
+**Alternative considered + rejected:** assigning `EksTokenError.exit_code = 7` for finer-grained observability. Rejected because the logging layer (Phase 1 OBS-01) already emits the typed error class name via structlog — exit-code differentiation duplicates that signal without consumer-facing value.
+
+**No action item:** documented for traceability; reviewer can override if they prefer distinct exit codes.
+</deviations>
+
+<dependencies_on_prior_plans>
+## Prior Plan Inputs
+
+- **Phase 1 (toolchain-spine — ALL plans merged on `phase/01-toolchain-spine`):**
+  - `pyproject.toml`: `boto3 ~= 1.43`, `moto[eks,sts] ~= 5.2`, `boto3-stubs[eks,sts]`, `pytest-mock ~= 3.15`, `pytest ~= 9.1`, `ruff ~= 0.15`, `mypy ~= 2.1` — all installed; ZERO new packages added.
+  - `src/aws_eks_helm_deploy/errors.py`: `PipeError` base + 6 subclasses already shipped (exit codes 1..6); this plan extends the file with `EksTokenError(PipeError)`.
+  - `src/aws_eks_helm_deploy/settings.py`: `Settings.aws_region` field already defined (alias `AWS_REGION`, default `"eu-central-1"`); the future `select_strategy()` (Plan 02-04) will pass `settings.aws_region` as the `region` argument to `generate_eks_token`.
+  - `tests/conftest.py`: `pytest_collection_modifyitems` auto-marks `tests/unit/` tests as `unit` — new `test_eks_token.py` falls under this hook (explicit `@pytest.mark.unit` still added for clarity).
+  - Coverage gate `--cov-fail-under=100` is ACTIVE — new `eks_token.py` must hit 100% line+branch from day one.
+
+## NOT dependencies (sibling plans run in parallel)
+
+- This plan does NOT depend on Plan 02-02 (`auth/base.py`) — the token generator takes a pre-built `boto3.Session`, not an `AwsCredentials` value object.
+- This plan does NOT depend on Plans 02-03 or 02-04.
+</dependencies_on_prior_plans>
+
+<dependencies_on_other_phases>
+## Forward Compatibility
+
+- **Plan 02-04 (`auth/__init__.py::select_strategy` + cli wire-in):** will call `generate_eks_token(session, settings.cluster_name, settings.aws_region)` after selecting a strategy and building a session from `AwsCredentials.to_boto3_kwargs()`. The signature `(session, cluster_name, region) -> str` is the stable contract this plan ships.
+- **Phase 3 (Helm Core & Upgrade Action):** `kube/kubeconfig.py` (Phase 3 deliverable) will receive the token string and inline it into the `users[0].user.token` field of the kubeconfig YAML. The token contract is "opaque string starting with `k8s-aws-v1.`" — Phase 3 does not introspect the payload.
+- **Phase 4 (OIDC strategy):** the `OidcWebIdentityStrategy` returns `AwsCredentials` like any other strategy; the wire-in still calls `generate_eks_token(session, ...)`. Zero changes to `eks_token.py` are required when OIDC ships.
+
+## Stable contract (do NOT refactor without bumping major)
+
+```
+generate_eks_token(
+    session: boto3.session.Session,
+    cluster_name: str,
+    region: str,
+) -> str  # token string starting with "k8s-aws-v1."
+```
+</dependencies_on_other_phases>
+
+<known_stubs>
+## Known Stubs / Scaffolds
+
+None. This module ships at its final Phase-2-scope behavior. There is no "TODO Phase N" comment in `eks_token.py`.
+
+Two NON-stub design choices to document:
+- **Closure-based event store:** `_header_store: dict[str, str]` is a local closure dict — not module-level state — so concurrent calls (if ever introduced) do NOT collide. The Bitbucket Pipe is single-invocation, so concurrency is not a concern in practice; the closure-dict pattern follows the awscli upstream literally for auditability.
+- **Hardcoded `URL_TIMEOUT = 60`:** matches `aws-iam-authenticator`'s `v1Prefix` token validity window. The 15-minute end-to-end token validity is enforced cluster-side, not via this constant. Do NOT make `URL_TIMEOUT` configurable — upstream tooling does not, and a configurable value would make tokens out-of-spec.
+</known_stubs>
+
+<verification>
+- `uv run ruff check src tests` exits 0.
+- `uv run ruff format --check src tests` exits 0.
+- `uv run mypy --strict src` exits 0.
+- `uv run pytest -m unit -q tests/unit/test_eks_token.py --cov=aws_eks_helm_deploy.aws.eks_token --cov-branch --cov-fail-under=100` exits 0.
+- `uv run pytest -m unit -q tests/unit/test_errors.py --no-cov` exits 0 (existing tests + new `EksTokenError` tests).
+- `uv run pytest -q` (full unit tier with the 100% gate) exits 0 — no regression in the 33+ Phase 1 tests.
+- Audit grep: `grep -RIn "awscli" src/` returns NO lines (proves AUTH-07 "no awscli dependency in runtime image"). This audit is recorded in 02-VALIDATION.md.
+- `python -c "from aws_eks_helm_deploy.aws.eks_token import generate_eks_token; print('OK')"` exits 0.
+</verification>
+
+<success_criteria>
+- AUTH-07: `aws_eks_helm_deploy.aws.eks_token.generate_eks_token` produces a `k8s-aws-v1.<base64url-no-padding>` token using only `boto3` + `botocore` (no `awscli` import in the codebase per audit grep).
+- 100% line+branch coverage on `src/aws_eks_helm_deploy/aws/eks_token.py`.
+- `EksTokenError` is part of the typed error hierarchy with `exit_code == 3`.
+- All Phase 1 tests still pass (no regression).
+- ROADMAP Phase 2 SC2 "byte-equal" wording deviation is documented (this plan's `<deviations>` block).
+- Stable contract published for downstream plans: `generate_eks_token(session, cluster_name, region) -> str`.
+</success_criteria>
+
+<artifacts>
+## Artifacts this plan produces (Plan 02-01 scope)
+
+**Files (new):**
+- `src/aws_eks_helm_deploy/aws/__init__.py` — empty subpackage marker.
+- `src/aws_eks_helm_deploy/aws/eks_token.py` — `generate_eks_token` + constants `TOKEN_PREFIX`, `K8S_AWS_ID_HEADER`, `URL_TIMEOUT`.
+- `tests/unit/test_eks_token.py` — 10+ structural-equivalence tests under `@mock_aws`.
+
+**Files (modified):**
+- `src/aws_eks_helm_deploy/errors.py` — appended `EksTokenError(PipeError)` (exit_code=3); header docstring updated to list the new class.
+- `tests/unit/test_errors.py` — appended two tests for `EksTokenError`.
+
+**New Python symbols (importable):**
+- `aws_eks_helm_deploy.aws.eks_token.generate_eks_token(session, cluster_name, region) -> str`
+- `aws_eks_helm_deploy.aws.eks_token.TOKEN_PREFIX: Final[str] = "k8s-aws-v1."`
+- `aws_eks_helm_deploy.aws.eks_token.K8S_AWS_ID_HEADER: Final[str] = "x-k8s-aws-id"`
+- `aws_eks_helm_deploy.aws.eks_token.URL_TIMEOUT: Final[int] = 60`
+- `aws_eks_helm_deploy.errors.EksTokenError(PipeError)` — exit_code=3.
+
+**Stubs (explicitly called out):**
+- None — the module ships at its final Phase 2 behavior.
+
+**Out of scope for this plan:**
+- Session construction (lives in Plans 02-02, 02-03, 02-04).
+- Wire-in to `cli.main` (lives in Plan 02-04).
+- `Dockerfile` changes (Phase 1 already removed `awscli`; nothing to do here).
+- The audit grep gate (`grep -RIn awscli src/` returns nothing) is documented in `02-VALIDATION.md`, not implemented as a unit test.
+</artifacts>
+
+<output>
+On completion, create `.planning/phases/02-aws-layer-auth-foundation/02-01-SUMMARY.md` recording:
+- Final coverage % on `src/aws_eks_helm_deploy/aws/eks_token.py` (must be 100%).
+- Whether the `botocore.exceptions.NoCredentialsError` branch was exercised by a test (yes/no — should be yes).
+- Whether any `# type: ignore` comments landed in `eks_token.py` (and the rationale).
+- The exact `boto3` / `botocore` / `moto` versions observed in the venv at the time of execution (for ADR Phase 7 traceability).
+- Confirmation that `grep -RIn 'awscli' src/` returned no lines.
+- The two structural deviations (byte-equal → structural equivalence; shared exit code 3 with ClusterAccessError) re-stated for ADR traceability.
+</output>

--- a/.planning/phases/02-aws-layer-auth-foundation/02-02-PLAN.md
+++ b/.planning/phases/02-aws-layer-auth-foundation/02-02-PLAN.md
@@ -1,0 +1,327 @@
+---
+phase: 02-aws-layer-auth-foundation
+plan: 2
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/aws_eks_helm_deploy/auth/__init__.py
+  - src/aws_eks_helm_deploy/auth/base.py
+  - tests/unit/test_auth_base.py
+autonomous: true
+requirements:
+  - AUTH-01
+tags:
+  - auth
+  - protocol
+  - dataclass
+  - aws-credentials
+  - typing
+
+must_haves:
+  truths:
+    - "`from aws_eks_helm_deploy.auth.base import AuthStrategy, AwsCredentials` resolves; both symbols are public exports of `auth.base`."
+    - "`AuthStrategy` is a `typing.Protocol` decorated with `@runtime_checkable` so `isinstance(obj, AuthStrategy)` returns True for any object exposing a `get_credentials(self) -> AwsCredentials` method."
+    - "`AwsCredentials` is a `dataclasses.dataclass(frozen=True)` with exactly four fields in this order: `access_key_id: str`, `secret_access_key: str`, `session_token: str | None = None`, `expiration: datetime | None = None`."
+    - "Mutating any field on an `AwsCredentials` instance raises `dataclasses.FrozenInstanceError`."
+    - "`repr(AwsCredentials(...))` masks the secret: the string contains `<redacted>` for `secret_access_key` and shows ONLY the last 4 characters of `access_key_id` prefixed with `...`."
+    - "`AwsCredentials(...).to_boto3_kwargs()` returns `{\"aws_access_key_id\": ..., \"aws_secret_access_key\": ...}` when `session_token is None`."
+    - "`AwsCredentials(..., session_token='X').to_boto3_kwargs()` returns the dict above PLUS the key `aws_session_token`."
+    - "`mypy --strict src` exits 0 — the Protocol + dataclass are fully type-annotated."
+    - "100% line + branch coverage on `src/aws_eks_helm_deploy/auth/base.py` is achieved by `tests/unit/test_auth_base.py`."
+  artifacts:
+    - path: "src/aws_eks_helm_deploy/auth/__init__.py"
+      provides: "Empty namespace marker for the `auth` subpackage. `select_strategy()` is added by Plan 02-04 — NOT by this plan."
+      contains: "from __future__ import annotations"
+    - path: "src/aws_eks_helm_deploy/auth/base.py"
+      provides: "`AuthStrategy` Protocol + `AwsCredentials` frozen dataclass with `to_boto3_kwargs()` method and masked `__repr__`."
+      contains: "class AuthStrategy"
+      min_lines: 50
+    - path: "tests/unit/test_auth_base.py"
+      provides: "Unit tests for `AwsCredentials` (repr masking, to_boto3_kwargs, frozenness) and `AuthStrategy` runtime-checkable behavior."
+      contains: "from aws_eks_helm_deploy.auth.base import"
+      min_lines: 80
+  key_links:
+    - from: "src/aws_eks_helm_deploy/auth/base.py::AuthStrategy"
+      to: "typing.Protocol with @runtime_checkable"
+      via: "@runtime_checkable decorator"
+      pattern: "@runtime_checkable"
+    - from: "src/aws_eks_helm_deploy/auth/base.py::AwsCredentials"
+      to: "dataclasses module"
+      via: "@dataclass(frozen=True)"
+      pattern: "@dataclasses\\.dataclass\\(frozen=True\\)"
+    - from: "src/aws_eks_helm_deploy/auth/base.py::AwsCredentials.__repr__"
+      to: "credential redaction"
+      via: "returns string containing '<redacted>'"
+      pattern: "<redacted>"
+    - from: "src/aws_eks_helm_deploy/auth/base.py::AwsCredentials.to_boto3_kwargs"
+      to: "boto3.Session constructor kwargs"
+      via: "returns dict[str, str] suitable for **spreading"
+      pattern: "aws_access_key_id"
+---
+
+<objective>
+Ship the typed contracts that the three strategy implementations (02-03) and the composition root (02-04) consume: the `AuthStrategy` Protocol and the `AwsCredentials` frozen value object. After this plan, downstream plans can import `from aws_eks_helm_deploy.auth.base import AuthStrategy, AwsCredentials` and rely on a stable structural-typing contract — no inheritance required.
+
+Purpose: Closes the typed-Protocol half of AUTH-01 ("`src/aws_eks_helm_deploy/auth/base.py` defines the `AuthStrategy` Protocol and `AwsCredentials` value object"). The strategy IMPLEMENTATIONS (StaticKeys, AssumeRole) ship in Plan 02-03; this plan provides the contracts they satisfy structurally.
+
+Output:
+- `src/aws_eks_helm_deploy/auth/` subpackage (new) with empty `__init__.py` and `base.py`.
+- `tests/unit/test_auth_base.py` — full coverage of `AwsCredentials` (default fields, repr masking, to_boto3_kwargs with/without session_token, frozenness, equality) and `AuthStrategy` Protocol (runtime-checkable isinstance behavior with a conforming + non-conforming object).
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md
+@src/aws_eks_helm_deploy/errors.py
+@src/aws_eks_helm_deploy/logging.py
+@pyproject.toml
+@tests/unit/test_settings.py
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 02-2-01: auth/ subpackage skeleton + AuthStrategy Protocol + AwsCredentials dataclass</name>
+  <files>src/aws_eks_helm_deploy/auth/__init__.py, src/aws_eks_helm_deploy/auth/base.py, tests/unit/test_auth_base.py</files>
+  <read_first>
+    - .planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md (Section B — full `AuthStrategy` + `AwsCredentials` code pattern verified in project venv; Section D — complete AwsCredentials field spec; Section I — STRIDE row T-02-02-01 on credential repr disclosure)
+    - src/aws_eks_helm_deploy/logging.py (existing `CREDENTIAL_BLOCKLIST` includes `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` — `bind_safe_context(**creds.to_boto3_kwargs())` MUST raise `ValueError`. This is the integration assertion.)
+    - src/aws_eks_helm_deploy/errors.py (existing PipeError hierarchy — this plan adds NO new error classes; the strategies in Plan 02-03 reuse `AuthenticationError`/`ConfigurationError`)
+    - .planning/phases/01-toolchain-spine/01-01-PLAN.md (Plan A patterns — `from __future__ import annotations` as first non-docstring line; module docstring with requirement traceability header; mypy-strict; full type annotations)
+  </read_first>
+  <behavior>
+    - `src/aws_eks_helm_deploy/auth/__init__.py` is an empty marker (one-line docstring + `from __future__ import annotations`). The `select_strategy()` function and `__all__` re-exports are added by Plan 02-04 — this plan deliberately leaves `__init__.py` blank.
+    - `src/aws_eks_helm_deploy/auth/base.py` exposes exactly two public symbols:
+      1. `AuthStrategy` — a `typing.Protocol` decorated with `@runtime_checkable`. The Protocol declares a single method: `def get_credentials(self) -> AwsCredentials: ...`. The Protocol body uses `...` (literal Ellipsis), not `pass` — this is the canonical Protocol pattern (Python typing PEP 544).
+      2. `AwsCredentials` — a `dataclasses.dataclass(frozen=True)` with fields exactly as in RESEARCH Section D:
+         - `access_key_id: str` (no default — required)
+         - `secret_access_key: str` (no default — required)
+         - `session_token: str | None = None`
+         - `expiration: datetime | None = None`
+    - `AwsCredentials.__repr__(self) -> str` returns: `f"AwsCredentials(access_key_id=...{tail}, secret_access_key=<redacted>)"` where `tail = self.access_key_id[-4:] if len(self.access_key_id) >= 4 else "****"`. The `repr` MUST NOT include `session_token` value OR `expiration` (both deliberately omitted — they leak less but are not in the contract; if `session_token` is present we MAY append `session_token=<redacted>` in the repr, but the default is to omit the field entirely. Decision: include `session_token=<redacted>` if `session_token is not None` to make presence-vs-absence visible without leaking value. Omit `expiration` because it is informational only).
+    - `AwsCredentials.to_boto3_kwargs(self) -> dict[str, str]` returns:
+      - `{"aws_access_key_id": self.access_key_id, "aws_secret_access_key": self.secret_access_key}` when `session_token is None`
+      - PLUS `"aws_session_token": self.session_token` when `session_token` is set
+      - `expiration` is NEVER included (it is not a boto3 Session kwarg; it is metadata for refresh logic — Phase 2 does not refresh since the pipe runs once-and-exits)
+    - The dataclass `frozen=True` AND `slots=False` (do NOT add `slots=True` — `slots` interacts poorly with custom `__repr__` overrides in some scenarios and is not needed; keep the dataclass conservative).
+    - The Protocol's `get_credentials` method has NO default implementation; concrete classes (Plan 02-03) provide it. Type-checker contract: classes implementing the Protocol need not inherit — they need only the method signature.
+    - `isinstance(obj, AuthStrategy)` returns True for an object that has a `get_credentials()` method (runtime-checkable), False otherwise.
+    - `bind_safe_context(**creds.to_boto3_kwargs())` (calling the Phase 1 wrapper) MUST raise `ValueError` because `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token` are all in `CREDENTIAL_BLOCKLIST`. The test asserts this is the expected behavior, NOT a bug — it documents the contract that callers must not bind raw creds.
+    - `mypy --strict src` exits 0 with the new module.
+    - 100% line+branch coverage on `base.py`. The `__repr__` short-key branch (`len < 4`) must be exercised.
+
+    Test list (all under `tests/unit/test_auth_base.py`, all `@pytest.mark.unit`):
+    - `test_aws_credentials_default_session_token_is_none` — `AwsCredentials("AKIA...", "secret").session_token is None`.
+    - `test_aws_credentials_default_expiration_is_none` — `expiration is None`.
+    - `test_aws_credentials_with_session_token` — `AwsCredentials(..., session_token="X").session_token == "X"`.
+    - `test_aws_credentials_with_expiration` — pass a `datetime(2026, 1, 1, tzinfo=UTC)`, assert it's the field value.
+    - `test_aws_credentials_is_frozen_access_key` — `creds.access_key_id = "X"` raises `dataclasses.FrozenInstanceError`.
+    - `test_aws_credentials_is_frozen_secret` — same for `secret_access_key`.
+    - `test_aws_credentials_repr_masks_secret` — `assert "secret" not in repr(creds)` AND `assert "<redacted>" in repr(creds)`.
+    - `test_aws_credentials_repr_shows_last_four_of_access_key` — `creds = AwsCredentials("AKIAIOSFODNN7EXAMPLE", ...)`, assert `"...MPLE" in repr(creds)` (last 4 chars).
+    - `test_aws_credentials_repr_short_access_key` — `creds = AwsCredentials("AKI", ...)`, assert `"****" in repr(creds)` (the `len < 4` branch).
+    - `test_aws_credentials_repr_includes_session_token_marker_when_set` — `assert "session_token=<redacted>" in repr(AwsCredentials(..., session_token="X"))`.
+    - `test_aws_credentials_repr_omits_session_token_marker_when_none` — `assert "session_token" not in repr(AwsCredentials(...))`.
+    - `test_to_boto3_kwargs_without_session_token` — exact dict equality `{"aws_access_key_id": ..., "aws_secret_access_key": ...}`.
+    - `test_to_boto3_kwargs_with_session_token` — exact dict equality including `aws_session_token`.
+    - `test_to_boto3_kwargs_omits_expiration` — pass `expiration=datetime(...)`, assert `"expiration"` not in returned dict keys.
+    - `test_aws_credentials_equality` — two `AwsCredentials` with identical fields are `==`; with differing fields are `!=` (dataclass auto-generates `__eq__`).
+    - `test_aws_credentials_hashable` — `hash(AwsCredentials(...))` does not raise (frozen dataclasses are hashable). Use a tuple key in a dict to demonstrate.
+    - `test_auth_strategy_is_runtime_checkable_positive` — a duck-typed object with a `get_credentials` method passes `isinstance(obj, AuthStrategy)`.
+    - `test_auth_strategy_is_runtime_checkable_negative` — `isinstance(object(), AuthStrategy)` is False.
+    - `test_aws_credentials_to_boto3_kwargs_collides_with_blocklist` — assert that calling `from aws_eks_helm_deploy.logging import bind_safe_context; bind_safe_context(**creds.to_boto3_kwargs())` raises `ValueError`. This documents the contract that downstream callers MUST NOT bind raw creds to structlog context.
+  </behavior>
+  <action>
+    Create `src/aws_eks_helm_deploy/auth/__init__.py`:
+    - Line 1: docstring `"""Auth subpackage — AuthStrategy Protocol + concrete strategy implementations."""`.
+    - Line 2 blank.
+    - Line 3: `from __future__ import annotations`.
+    - No re-exports (Plan 02-04 adds `select_strategy` and may choose to re-export).
+
+    Create `src/aws_eks_helm_deploy/auth/base.py` per RESEARCH Section B verified pattern:
+    - Module docstring with AUTH-01 traceability header, mirroring `settings.py` style.
+    - `from __future__ import annotations`.
+    - Imports: `dataclasses`, `from datetime import datetime`, `from typing import Protocol, runtime_checkable`.
+    - Class definition order: `AwsCredentials` FIRST, `AuthStrategy` SECOND (Protocol references the dataclass in its method signature). Use `from __future__ import annotations` so the forward reference works without quoting.
+    - `AwsCredentials` exactly per behavior contract above. Implement `__repr__` AND `to_boto3_kwargs` as explicit methods.
+    - `AuthStrategy` Protocol exactly per RESEARCH Section B — `@runtime_checkable` decorator above `class AuthStrategy(Protocol):`. The single method body is `...` (literal Ellipsis).
+    - Module-level `__all__: list[str] = ["AwsCredentials", "AuthStrategy"]` so `from aws_eks_helm_deploy.auth.base import *` is explicit (also satisfies ruff `F401` if any).
+    - mypy-strict: all method signatures typed; `dict[str, str]` in `to_boto3_kwargs` (NOT `dict[str, Any]` — values are always strings). NO `# type: ignore` should be needed.
+
+    Create `tests/unit/test_auth_base.py` per the behavior list:
+    - Module docstring referencing AUTH-01.
+    - `from __future__ import annotations`.
+    - imports: `dataclasses`, `from datetime import UTC, datetime`, `pytest`, `from aws_eks_helm_deploy.auth.base import AuthStrategy, AwsCredentials`.
+    - Each test `@pytest.mark.unit`.
+    - For the runtime-checkable tests, define a small in-test class:
+      ```
+      class _Conformant:
+          def get_credentials(self) -> AwsCredentials:
+              return AwsCredentials("AKIA...", "secret")
+      ```
+      and assert `isinstance(_Conformant(), AuthStrategy) is True`.
+    - For the blocklist integration test, import `from aws_eks_helm_deploy.logging import bind_safe_context`. Mark in the docstring that this test enforces the CONTRACT, not just a bug — see RESEARCH Section B "Integration with CREDENTIAL_BLOCKLIST".
+
+    Confirm `uv run pytest -m unit -q tests/unit/test_auth_base.py --cov=aws_eks_helm_deploy.auth.base --cov-branch --cov-fail-under=100` exits 0.
+
+    Stub call-out: `auth/__init__.py` is intentionally empty. Plan 02-04 will populate it with `select_strategy(settings) -> AuthStrategy` and possibly re-export. This split keeps Plan 02-02 atomic (only contracts, no composition logic).
+  </action>
+  <verify>
+    <automated>uv run ruff check src tests &amp;&amp; uv run ruff format --check src tests &amp;&amp; uv run mypy --strict src &amp;&amp; uv run pytest -m unit -q tests/unit/test_auth_base.py --cov=aws_eks_helm_deploy.auth.base --cov-branch --cov-fail-under=100 --no-header</automated>
+  </verify>
+  <done>
+    `AuthStrategy` Protocol + `AwsCredentials` dataclass are importable and behave per all behavior bullets; `tests/unit/test_auth_base.py` is at 100% line+branch coverage on `auth/base.py`; `ruff check`, `ruff format --check`, `mypy --strict src` all exit 0; `bind_safe_context(**creds.to_boto3_kwargs())` raises `ValueError` (contract documented).
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| `AwsCredentials` instance → log streams (pipe stdout / structlog stderr) | The dataclass owns its own `__repr__`. Any code path that logs an `AwsCredentials` instance (e.g., `logger.info("creds=%r", creds)`) MUST go through the masked repr. |
+| `AwsCredentials.to_boto3_kwargs()` → `boto3.Session(**kwargs)` | The kwargs dict is consumed by boto3 internally — it does NOT enter our log surface. |
+| `AwsCredentials.to_boto3_kwargs()` → `bind_safe_context()` (incorrectly) | Phase 1's `CREDENTIAL_BLOCKLIST` causes this to raise. This is the INTENDED behavior — the test enforces it as a contract. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-02-01 | Information Disclosure | `AwsCredentials.__repr__` accidentally exposes the secret | mitigate | `__repr__` is overridden explicitly; tests assert `"secret"` not in `repr(creds)` AND `"<redacted>"` in `repr(creds)`. The test for the short-access-key branch ensures the `len < 4` path uses `****` (no key value leak). |
+| T-02-02-02 | Information Disclosure | Caller spreads `creds.to_boto3_kwargs()` into `bind_safe_context()` | mitigate | This intentionally raises `ValueError` because `aws_access_key_id`/`aws_secret_access_key`/`aws_session_token` are in `CREDENTIAL_BLOCKLIST`. A dedicated unit test enforces this contract so future refactors can't silently strip the guard. |
+| T-02-02-03 | Tampering | Mutable dataclass allows post-construction credential rotation in unintended places | mitigate | `frozen=True` raises `FrozenInstanceError` on assignment. Two dedicated tests cover access_key_id and secret_access_key mutation attempts. |
+| T-02-02-04 | Repudiation | `expiration` field is leaked to logs revealing AWS session topology | accept | `expiration` is informational only and NOT included in `to_boto3_kwargs()`. It's omitted from `__repr__` by design. No logger directly references it in this plan; if Phase 4 OIDC strategy starts using it for refresh logic, the logging-emit decision is re-evaluated then. |
+| T-02-02-SC | Tampering | Package legitimacy — only standard library imports | mitigate | This plan introduces ZERO external imports. `dataclasses`, `datetime`, `typing` are all stdlib. No supply-chain surface. |
+</threat_model>
+
+<deviations>
+## Documented Deviations from ROADMAP / RESEARCH
+
+### Deviation 1: `expiration` field is omitted from `__repr__`
+
+**Decision:** `AwsCredentials.__repr__` does NOT include `expiration` even when it is set.
+
+**Rationale:** `expiration` is a `datetime` from STS AssumeRole responses. Including it in logs reveals AWS session topology to log consumers. It's used by Phase 4's OIDC strategy for prospective refresh logic — but Phase 2 never refreshes (one-shot pipe). Until a consumer demonstrably benefits from seeing expiration in logs, the conservative default is to omit it. The field IS available on the instance via attribute access for in-pipe logic.
+
+**Action item:** If Phase 4 OIDC ever needs the expiration visible in logs (e.g., for debugging a refresh loop), revisit this decision and add `expiration={iso}` to repr at that time. Until then, omitting is safer.
+
+### Deviation 2: `__repr__` includes `session_token=<redacted>` MARKER (but not value)
+
+**Decision:** When `session_token is not None`, the repr appends `, session_token=<redacted>`. When it is `None`, no marker is added.
+
+**Rationale:** Operators reading logs benefit from knowing whether the credentials carry a session token (temporary) vs not (long-term). The presence/absence is operationally relevant (e.g., when debugging `ExpiredToken` errors). The value itself is `<redacted>`, so there's no IDp risk.
+
+**Alternative considered + rejected:** always include `session_token=<redacted>` (even when None). Rejected because it makes the repr noisier without information value.
+</deviations>
+
+<dependencies_on_prior_plans>
+## Prior Plan Inputs
+
+- **Phase 1 (toolchain-spine — ALL plans merged):**
+  - `pyproject.toml`: `python ~= 3.13`, `ruff ~= 0.15`, `mypy ~= 2.1`, `pytest ~= 9.1` — all installed.
+  - `src/aws_eks_helm_deploy/logging.py::CREDENTIAL_BLOCKLIST` — used by the blocklist-integration test; this plan does NOT modify `logging.py`.
+  - `tests/conftest.py::pytest_collection_modifyitems` — auto-marks unit tests; explicit `@pytest.mark.unit` still added for clarity.
+  - Coverage gate `--cov-fail-under=100` is ACTIVE — `base.py` must hit 100% from day one.
+
+## NOT dependencies (sibling plans run in parallel)
+
+- This plan does NOT depend on Plan 02-01 (`aws/eks_token.py`) — Protocol + dataclass are session-agnostic.
+- This plan SHIPS the contract that Plans 02-03 and 02-04 consume; those plans wait for THIS plan via `depends_on: ["02-02"]`.
+</dependencies_on_prior_plans>
+
+<dependencies_on_other_phases>
+## Forward Compatibility
+
+- **Plan 02-03 (StaticKeysStrategy + AssumeRoleStrategy):** both classes will satisfy `AuthStrategy` Protocol structurally — they define `def get_credentials(self) -> AwsCredentials`. No inheritance. The Protocol is the contract.
+- **Plan 02-04 (`select_strategy` + cli wire-in):** `select_strategy(settings) -> AuthStrategy` is the public composition root. It returns one of the strategies. The cli will call `creds = strategy.get_credentials()`, build a `boto3.Session(region_name=settings.aws_region, **creds.to_boto3_kwargs())`, and pass it to `generate_eks_token` from Plan 02-01.
+- **Phase 4 (`auth/oidc.py::OidcWebIdentityStrategy`):** ships independently in Phase 4. Because `AuthStrategy` is a `Protocol` (not an ABC), `OidcWebIdentityStrategy` does NOT need to inherit from anything in `base.py`. It satisfies the Protocol structurally. Zero coupling.
+- **Future Pod Identity / aws-vault (v2.1+):** same pattern — implement `get_credentials() -> AwsCredentials`, no inheritance.
+
+## Stable contract (do NOT refactor without bumping major)
+
+```
+@runtime_checkable
+class AuthStrategy(Protocol):
+    def get_credentials(self) -> AwsCredentials: ...
+
+@dataclasses.dataclass(frozen=True)
+class AwsCredentials:
+    access_key_id: str
+    secret_access_key: str
+    session_token: str | None = None
+    expiration: datetime | None = None
+
+    def to_boto3_kwargs(self) -> dict[str, str]: ...
+    def __repr__(self) -> str: ...  # masks secret_access_key, shows last-4 of access_key_id
+```
+</dependencies_on_other_phases>
+
+<known_stubs>
+## Known Stubs / Scaffolds
+
+- **`src/aws_eks_helm_deploy/auth/__init__.py` is intentionally empty** — Plan 02-04 populates it with `select_strategy(settings: Settings) -> AuthStrategy`. Splitting the contracts from the composition root keeps each plan atomic. The empty `__init__.py` is NOT a stub in the negative sense — it is the correct shape for Plan 02-02's scope.
+
+No code paths in `base.py` are stubs; everything ships at its final Phase-2 behavior.
+</known_stubs>
+
+<verification>
+- `uv run ruff check src tests` exits 0.
+- `uv run ruff format --check src tests` exits 0.
+- `uv run mypy --strict src` exits 0.
+- `uv run pytest -m unit -q tests/unit/test_auth_base.py --cov=aws_eks_helm_deploy.auth.base --cov-branch --cov-fail-under=100` exits 0.
+- `uv run pytest -q` (full unit tier with 100% gate) exits 0 — no regression in 33+ Phase 1 tests OR in Plan 02-01's `test_eks_token.py`.
+- `python -c "from aws_eks_helm_deploy.auth.base import AuthStrategy, AwsCredentials; c = AwsCredentials('AKIA-FAKE-EXAMPLE', 'secret'); assert '<redacted>' in repr(c) and 'secret' not in repr(c)"` exits 0.
+- `python -c "from aws_eks_helm_deploy.auth.base import AwsCredentials; from aws_eks_helm_deploy.logging import bind_safe_context; bind_safe_context(**AwsCredentials('AKIA','s').to_boto3_kwargs())"` exits non-zero (asserts the blocklist contract).
+</verification>
+
+<success_criteria>
+- AUTH-01 (Protocol half): `auth/base.py` defines `AuthStrategy` Protocol and `AwsCredentials` dataclass per RESEARCH Section B / D verified contracts.
+- 100% line+branch coverage on `src/aws_eks_helm_deploy/auth/base.py`.
+- `bind_safe_context(**creds.to_boto3_kwargs())` raises `ValueError` — contract enforced by unit test.
+- `mypy --strict src` exits 0.
+- Stable contracts published for Plans 02-03 and 02-04 consumption.
+- Stubs explicitly named: `auth/__init__.py` is empty (Plan 02-04 adds `select_strategy()`).
+</success_criteria>
+
+<artifacts>
+## Artifacts this plan produces (Plan 02-02 scope)
+
+**Files (new):**
+- `src/aws_eks_helm_deploy/auth/__init__.py` — empty subpackage marker (docstring + `from __future__ import annotations`).
+- `src/aws_eks_helm_deploy/auth/base.py` — `AuthStrategy` Protocol + `AwsCredentials` dataclass.
+- `tests/unit/test_auth_base.py` — 17+ unit tests covering all behavior bullets.
+
+**New Python symbols (importable):**
+- `aws_eks_helm_deploy.auth.base.AuthStrategy` (Protocol, `@runtime_checkable`).
+- `aws_eks_helm_deploy.auth.base.AwsCredentials` (frozen dataclass).
+- `AwsCredentials.to_boto3_kwargs() -> dict[str, str]`.
+- `AwsCredentials.__repr__() -> str` (masked).
+
+**Stubs (explicitly called out):**
+- `auth/__init__.py` is empty by design; Plan 02-04 adds `select_strategy()`. Not a code stub — the correct shape for Plan 02-02 scope.
+
+**Out of scope for this plan:**
+- Concrete strategies (Plans 02-03).
+- `select_strategy` composition logic (Plan 02-04).
+- Token generation (Plan 02-01).
+- CLI wire-in (Plan 02-04).
+</artifacts>
+
+<output>
+On completion, create `.planning/phases/02-aws-layer-auth-foundation/02-02-SUMMARY.md` recording:
+- Final coverage % on `src/aws_eks_helm_deploy/auth/base.py` (must be 100%).
+- Confirmation that `bind_safe_context(**creds.to_boto3_kwargs())` raises `ValueError` (the blocklist contract test passes).
+- Whether the `len(access_key_id) < 4` branch in `__repr__` was exercised by a test (must be yes).
+- Confirmation that `auth/__init__.py` is empty (Plan 02-04 will fill it).
+- Exact `mypy` + `ruff` versions observed in the venv for ADR traceability.
+</output>

--- a/.planning/phases/02-aws-layer-auth-foundation/02-03-PLAN.md
+++ b/.planning/phases/02-aws-layer-auth-foundation/02-03-PLAN.md
@@ -1,0 +1,389 @@
+---
+phase: 02-aws-layer-auth-foundation
+plan: 3
+type: execute
+wave: 2
+depends_on:
+  - "02-02"
+files_modified:
+  - src/aws_eks_helm_deploy/auth/static_keys.py
+  - src/aws_eks_helm_deploy/auth/assume_role.py
+  - tests/unit/test_static_keys.py
+  - tests/unit/test_assume_role.py
+autonomous: true
+requirements:
+  - AUTH-01
+  - AUTH-02
+tags:
+  - auth
+  - sts
+  - assume-role
+  - static-keys
+  - moto
+
+must_haves:
+  truths:
+    - "`from aws_eks_helm_deploy.auth.static_keys import StaticKeysStrategy` resolves; instance is a structural `AuthStrategy` (via `isinstance(s, AuthStrategy)`)."
+    - "`StaticKeysStrategy(access_key_id, secret_access_key, session_token=None).get_credentials()` returns an `AwsCredentials` with the supplied values; `session_token` defaults to `None` and is propagated when set."
+    - "`from aws_eks_helm_deploy.auth.assume_role import AssumeRoleStrategy` resolves; instance is a structural `AuthStrategy`."
+    - "`AssumeRoleStrategy(base_strategy, role_arn, session_name, region)` calls `base_strategy.get_credentials()`, then constructs a `boto3.Session` from those credentials + `region`, then calls STS `assume_role`, and returns `AwsCredentials` with `access_key_id`, `secret_access_key`, `session_token`, and `expiration` populated from the STS response."
+    - "`AssumeRoleStrategy` targets the REGIONAL STS endpoint `sts.{region}.amazonaws.com` via explicit `endpoint_url` (NEVER the global endpoint)."
+    - "STS `ClientError` raised by `assume_role` is caught and re-raised as `AuthenticationError` (exit code 2); STS `NoCredentialsError` is caught and re-raised as `ConfigurationError` (exit code 1)."
+    - "Tests use `@mock_aws` from moto 5.2.x; no live AWS calls."
+    - "`mypy --strict src` exits 0 with the new modules."
+    - "100% line + branch coverage on both `auth/static_keys.py` AND `auth/assume_role.py`."
+  artifacts:
+    - path: "src/aws_eks_helm_deploy/auth/static_keys.py"
+      provides: "`StaticKeysStrategy` — wraps env-supplied static keys into an `AwsCredentials`. No AWS API calls; pure value-object construction."
+      contains: "class StaticKeysStrategy"
+      min_lines: 25
+    - path: "src/aws_eks_helm_deploy/auth/assume_role.py"
+      provides: "`AssumeRoleStrategy` — composes any `AuthStrategy` base and calls STS AssumeRole on top of its credentials."
+      contains: "class AssumeRoleStrategy"
+      min_lines: 50
+    - path: "tests/unit/test_static_keys.py"
+      provides: "Unit tests for StaticKeysStrategy — happy path, optional session_token propagation, Protocol conformance."
+      contains: "from aws_eks_helm_deploy.auth.static_keys import StaticKeysStrategy"
+      min_lines: 40
+    - path: "tests/unit/test_assume_role.py"
+      provides: "Unit tests for AssumeRoleStrategy under @mock_aws — happy path, ClientError → AuthenticationError, NoCredentialsError → ConfigurationError, base-strategy delegation."
+      contains: "from moto import mock_aws"
+      min_lines: 80
+  key_links:
+    - from: "src/aws_eks_helm_deploy/auth/static_keys.py::StaticKeysStrategy.get_credentials"
+      to: "src/aws_eks_helm_deploy/auth/base.py::AwsCredentials"
+      via: "return AwsCredentials(...)"
+      pattern: "return AwsCredentials"
+    - from: "src/aws_eks_helm_deploy/auth/assume_role.py::AssumeRoleStrategy.get_credentials"
+      to: "STS regional endpoint via boto3"
+      via: "session.client('sts', endpoint_url=f'https://sts.{region}.amazonaws.com')"
+      pattern: "endpoint_url=f.https://sts\\."
+    - from: "src/aws_eks_helm_deploy/auth/assume_role.py::AssumeRoleStrategy.get_credentials"
+      to: "src/aws_eks_helm_deploy/auth/base.py::AuthStrategy (base_strategy)"
+      via: "base_credentials = self._base.get_credentials()"
+      pattern: "self\\._base\\.get_credentials\\(\\)"
+    - from: "src/aws_eks_helm_deploy/auth/assume_role.py::AssumeRoleStrategy"
+      to: "errors.AuthenticationError / ConfigurationError"
+      via: "except ClientError: raise AuthenticationError(...) / except NoCredentialsError: raise ConfigurationError(...)"
+      pattern: "raise (AuthenticationError|ConfigurationError)"
+---
+
+<objective>
+Ship the two concrete `AuthStrategy` implementations Phase 2 commits to: `StaticKeysStrategy` (the trivial value-object wrapper — no AWS API calls) and `AssumeRoleStrategy` (the composable STS `AssumeRole` strategy that wraps any base `AuthStrategy`). After this plan, the typed Protocol from 02-02 has two real implementers, both validated under `@mock_aws`.
+
+Purpose: Closes the IMPLEMENTATION half of AUTH-01 (`StaticKeysStrategy`) and the full of AUTH-02 (`AssumeRoleStrategy` composable on top of any base credential source — parity with v1.x). The composition root that selects between them lives in Plan 02-04.
+
+Output:
+- `src/aws_eks_helm_deploy/auth/static_keys.py` — `StaticKeysStrategy(access_key_id, secret_access_key, session_token=None)`.
+- `src/aws_eks_helm_deploy/auth/assume_role.py` — `AssumeRoleStrategy(base, role_arn, session_name, region)`.
+- `tests/unit/test_static_keys.py` + `tests/unit/test_assume_role.py` — full coverage under `@mock_aws`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md
+@.planning/phases/02-aws-layer-auth-foundation/02-02-PLAN.md
+@src/aws_eks_helm_deploy/auth/base.py
+@src/aws_eks_helm_deploy/errors.py
+@src/aws_eks_helm_deploy/settings.py
+@pyproject.toml
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 02-3-01: StaticKeysStrategy — value-object wrapper, no AWS calls</name>
+  <files>src/aws_eks_helm_deploy/auth/static_keys.py, tests/unit/test_static_keys.py</files>
+  <read_first>
+    - .planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md (Section B — `AwsCredentials` field spec; Section E — strategy selection decision tree; Section G — test list per module)
+    - src/aws_eks_helm_deploy/auth/base.py (after Plan 02-02 merges — confirm `AuthStrategy` Protocol + `AwsCredentials` dataclass available)
+    - src/aws_eks_helm_deploy/settings.py (`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` field types — `str | None`; the strategy accepts non-None values; the composition root in Plan 02-04 enforces presence)
+    - .planning/phases/02-aws-layer-auth-foundation/02-02-PLAN.md (confirm `AwsCredentials` constructor signature: `access_key_id, secret_access_key, session_token=None, expiration=None`)
+  </read_first>
+  <behavior>
+    Module `src/aws_eks_helm_deploy/auth/static_keys.py` exposes:
+    - `class StaticKeysStrategy:` with `__init__(self, access_key_id: str, secret_access_key: str, session_token: str | None = None) -> None`.
+    - Constructor stores the three values as private attributes (`self._access_key_id`, etc.).
+    - `get_credentials(self) -> AwsCredentials` returns `AwsCredentials(access_key_id=self._access_key_id, secret_access_key=self._secret_access_key, session_token=self._session_token)`.
+    - NO AWS API calls. NO boto3 import (the module imports only `aws_eks_helm_deploy.auth.base.AwsCredentials`).
+    - `expiration` is NEVER set (long-term keys have no expiration; STS would NOT have returned them).
+    - The class structurally satisfies the `AuthStrategy` Protocol (single `get_credentials` method).
+    - mypy-strict-clean.
+
+    Test list (all under `tests/unit/test_static_keys.py`, `@pytest.mark.unit`):
+    - `test_static_keys_get_credentials_returns_expected_values` — `StaticKeysStrategy("AKIA-X", "secret-Y").get_credentials()` returns `AwsCredentials(access_key_id="AKIA-X", secret_access_key="secret-Y", session_token=None)`.
+    - `test_static_keys_session_token_default_is_none` — explicit assertion that `session_token` parameter defaults to `None`.
+    - `test_static_keys_propagates_session_token_when_set` — pass `session_token="T-X"`, assert `creds.session_token == "T-X"`.
+    - `test_static_keys_get_credentials_returns_same_values_on_repeat_calls` — calling `get_credentials()` twice returns equal `AwsCredentials` (no caching needed — the strategy is stateless).
+    - `test_static_keys_no_expiration` — `creds.expiration is None`.
+    - `test_static_keys_is_auth_strategy_protocol` — `from aws_eks_helm_deploy.auth.base import AuthStrategy; assert isinstance(StaticKeysStrategy("a", "b"), AuthStrategy)` (runtime-checkable Protocol conformance — proves zero-coupling via structural typing).
+    - `test_static_keys_constructor_signature_keyword_only_friendly` — `StaticKeysStrategy(access_key_id="a", secret_access_key="b", session_token="c")` works (kwarg style is the documented usage).
+  </behavior>
+  <action>
+    Create `src/aws_eks_helm_deploy/auth/static_keys.py`:
+    - Module docstring with AUTH-01 traceability and a one-liner "Static-keys strategy — wraps env-supplied keys into an `AwsCredentials`. No AWS calls."
+    - `from __future__ import annotations`.
+    - import: `from aws_eks_helm_deploy.auth.base import AwsCredentials`.
+    - Class definition with full type annotations on `__init__` and `get_credentials`.
+    - mypy-strict-clean — no `# type: ignore`.
+    - Module-level `__all__: list[str] = ["StaticKeysStrategy"]`.
+
+    Create `tests/unit/test_static_keys.py` per the behavior list:
+    - Module docstring referencing AUTH-01.
+    - `from __future__ import annotations`.
+    - imports: `pytest`, `from aws_eks_helm_deploy.auth.base import AwsCredentials, AuthStrategy`, `from aws_eks_helm_deploy.auth.static_keys import StaticKeysStrategy`.
+    - All seven tests as listed; each `@pytest.mark.unit`.
+    - Sample test (template):
+      ```
+      @pytest.mark.unit
+      def test_static_keys_get_credentials_returns_expected_values() -> None:
+          strategy = StaticKeysStrategy("AKIA-X", "secret-Y")
+          creds = strategy.get_credentials()
+          assert creds == AwsCredentials("AKIA-X", "secret-Y", None)
+      ```
+
+    Verify `uv run pytest -m unit -q tests/unit/test_static_keys.py --cov=aws_eks_helm_deploy.auth.static_keys --cov-branch --cov-fail-under=100` exits 0.
+
+    Stub call-out: NONE. The module ships at its final Phase 2 behavior; future Phase 4 OIDC strategy ships as a SEPARATE class (NOT a subclass of `StaticKeysStrategy`).
+  </action>
+  <verify>
+    <automated>uv run ruff check src tests &amp;&amp; uv run mypy --strict src &amp;&amp; uv run pytest -m unit -q tests/unit/test_static_keys.py --cov=aws_eks_helm_deploy.auth.static_keys --cov-branch --cov-fail-under=100 --no-header</automated>
+  </verify>
+  <done>
+    `StaticKeysStrategy` importable, returns expected `AwsCredentials`, satisfies `AuthStrategy` Protocol via runtime-checkable test, 100% line+branch coverage on the module, no AWS imports, mypy-strict-clean.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 02-3-02: AssumeRoleStrategy — STS AssumeRole on top of any base strategy</name>
+  <files>src/aws_eks_helm_deploy/auth/assume_role.py, tests/unit/test_assume_role.py</files>
+  <read_first>
+    - .planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md (Section C — boto3 session construction, regional STS endpoint, ClientError → typed error mapping, `CredentialsTypeDef` from `mypy_boto3_sts`; Section E — `AssumeRoleStrategy` ExternalId/MFA/duration scope; Section G — test list)
+    - src/aws_eks_helm_deploy/auth/base.py (after Plan 02-02 merges)
+    - src/aws_eks_helm_deploy/auth/static_keys.py (after Task 02-3-01 — used as the base strategy in tests)
+    - src/aws_eks_helm_deploy/errors.py (after Plan 02-01 — `AuthenticationError` exit_code=2; `ConfigurationError` exit_code=1; reuse, do NOT add new error types)
+    - .planning/phases/02-aws-layer-auth-foundation/02-01-PLAN.md (confirm `EksTokenError` exists but is NOT used here — assume-role failures are `AuthenticationError`)
+    - pyproject.toml (confirm `boto3 ~= 1.43`, `moto[eks,sts] ~= 5.2`, `boto3-stubs[eks,sts]` all already installed)
+  </read_first>
+  <behavior>
+    Module `src/aws_eks_helm_deploy/auth/assume_role.py` exposes:
+    - `class AssumeRoleStrategy:` with `__init__(self, base: AuthStrategy, role_arn: str, session_name: str, region: str) -> None`.
+    - The four constructor arguments are stored as `self._base`, `self._role_arn`, `self._session_name`, `self._region`.
+    - `get_credentials(self) -> AwsCredentials`:
+      1. Call `base_credentials = self._base.get_credentials()` — delegates to the wrapped strategy.
+      2. Construct a `boto3.Session(region_name=self._region, **base_credentials.to_boto3_kwargs())`.
+      3. Construct an STS client: `sts = session.client("sts", endpoint_url=f"https://sts.{self._region}.amazonaws.com", config=botocore.config.Config(retries={"max_attempts": 3, "mode": "standard"}))`.
+      4. Call `response = sts.assume_role(RoleArn=self._role_arn, RoleSessionName=self._session_name)` (no `DurationSeconds` — accept the AWS default of 3600s; no `ExternalId` — Phase 2 deferred per RESEARCH Section E).
+      5. Extract `creds = response["Credentials"]` (use `mypy_boto3_sts.type_defs.CredentialsTypeDef` for typing).
+      6. Return `AwsCredentials(access_key_id=creds["AccessKeyId"], secret_access_key=creds["SecretAccessKey"], session_token=creds["SessionToken"], expiration=creds["Expiration"])`.
+    - Wrap the `assume_role` call in `try/except`:
+      - `botocore.exceptions.ClientError as exc`: raise `AuthenticationError(f"STS AssumeRole failed [{exc.response['Error']['Code']}]: {exc.response['Error']['Message']}") from exc`.
+      - `botocore.exceptions.NoCredentialsError as exc`: raise `ConfigurationError("No AWS credentials found for STS AssumeRole") from exc`.
+    - The wrapped base strategy's `get_credentials()` is called EVERY TIME (no caching). Rationale (RESEARCH Section D): the pipe runs once and exits; refresh logic is unnecessary.
+    - `RoleSessionName` is taken VERBATIM from the constructor — no truncation in this strategy. Plan 02-04 derives the session name (with the `[:64]` truncation per AWS IAM limit) and passes it down. This module trusts its caller.
+    - mypy-strict-clean. Use `from mypy_boto3_sts.type_defs import CredentialsTypeDef` (already in `boto3-stubs[eks,sts] ~= 1.43`).
+
+    Test list (all under `tests/unit/test_assume_role.py`, `@pytest.mark.unit`):
+    - All tests use `@mock_aws` (outermost decorator on the test functions).
+    - `test_assume_role_happy_path` — wrap a `StaticKeysStrategy` as the base, call `get_credentials()`, assert the returned `AwsCredentials` has `session_token` set (moto returns a fake one) AND `expiration` set (moto returns a datetime).
+    - `test_assume_role_delegates_to_base` — wrap a `mocker.MagicMock(spec=AuthStrategy)` returning a known `AwsCredentials`, call `get_credentials()` on the AssumeRoleStrategy, assert the mock's `get_credentials` was called exactly once.
+    - `test_assume_role_uses_regional_sts_endpoint` — `mocker.patch.object(boto3.session.Session, "client")` to capture the `endpoint_url` kwarg; assert it equals `f"https://sts.{region}.amazonaws.com"`. (The mock returns a stub STS client whose `assume_role` returns a synthetic response per RESEARCH Section C field shape.)
+    - `test_assume_role_uses_supplied_region_in_endpoint` — call with `region="us-west-2"`, assert `endpoint_url` contains `"us-west-2"`.
+    - `test_assume_role_passes_role_arn_and_session_name` — patch `sts.assume_role` to capture kwargs; assert `RoleArn` and `RoleSessionName` match the constructor inputs.
+    - `test_assume_role_does_not_pass_duration_seconds` — same patch; assert `"DurationSeconds"` is NOT in the assume_role kwargs (we accept the AWS default).
+    - `test_assume_role_does_not_pass_external_id` — same patch; assert `"ExternalId"` is NOT in the kwargs.
+    - `test_assume_role_client_error_raises_authentication_error` — patch `sts.assume_role` to raise `botocore.exceptions.ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'No trust'}}, 'AssumeRole')`; assert `AuthenticationError` raised with `exit_code == 2`; assert `"AccessDenied"` appears in the error message.
+    - `test_assume_role_no_credentials_error_raises_configuration_error` — patch `sts.assume_role` to raise `botocore.exceptions.NoCredentialsError`; assert `ConfigurationError` raised with `exit_code == 1`.
+    - `test_assume_role_returns_credentials_with_expiration` — under `@mock_aws`, after a real assume_role call, assert `creds.expiration is not None` and `isinstance(creds.expiration, datetime)`.
+    - `test_assume_role_is_auth_strategy_protocol` — `isinstance(AssumeRoleStrategy(StaticKeysStrategy("a", "b"), "arn:aws:iam::123:role/X", "session", "eu-central-1"), AuthStrategy)` is True.
+    - `test_assume_role_propagates_base_session_token` — wrap a `StaticKeysStrategy(access_key_id="a", secret_access_key="b", session_token="T")` as the base. The base credentials include `session_token`; the STS assume-role call accepts them; the returned credentials carry STS's session token. The test verifies the chain works (no `aws_session_token` injection error in the boto3 Session construction).
+  </behavior>
+  <action>
+    Create `src/aws_eks_helm_deploy/auth/assume_role.py`:
+    - Module docstring with AUTH-02 traceability + a one-paragraph rationale ("Composable STS AssumeRole on top of any `AuthStrategy`. No caching — the pipe runs once and exits.").
+    - `from __future__ import annotations`.
+    - imports: `boto3`, `boto3.session`, `botocore.config`, `botocore.exceptions`, `from mypy_boto3_sts.type_defs import CredentialsTypeDef`, `from aws_eks_helm_deploy.auth.base import AuthStrategy, AwsCredentials`, `from aws_eks_helm_deploy.errors import AuthenticationError, ConfigurationError`.
+    - Class `AssumeRoleStrategy` per the behavior contract. Method bodies follow RESEARCH Section C verified pattern.
+    - Future-extension marker: `# ExternalId: Phase 2 deferred — see AUTH-NEXT (Phase 4 + IAM template work)` ABOVE the `sts.assume_role(...)` line (per RESEARCH Section E direction).
+    - Future-extension marker: `# Duration: omit DurationSeconds — accept AWS default 3600s per RESEARCH Section E` ABOVE the assume_role call.
+    - Module-level `__all__: list[str] = ["AssumeRoleStrategy"]`.
+    - Type the `assume_role` return as `dict[str, CredentialsTypeDef | ... ]` minimally — the simpler pattern from RESEARCH Section C is: `response = sts.assume_role(...); creds: CredentialsTypeDef = response["Credentials"]`. This is mypy-strict-clean.
+
+    Create `tests/unit/test_assume_role.py` per the behavior list:
+    - Module docstring referencing AUTH-02.
+    - `from __future__ import annotations`.
+    - imports: `pytest`, `boto3`, `botocore.exceptions`, `from datetime import datetime`, `from moto import mock_aws`, `from aws_eks_helm_deploy.auth.base import AuthStrategy, AwsCredentials`, `from aws_eks_helm_deploy.auth.static_keys import StaticKeysStrategy`, `from aws_eks_helm_deploy.auth.assume_role import AssumeRoleStrategy`, `from aws_eks_helm_deploy.errors import AuthenticationError, ConfigurationError`.
+    - For the kwarg-capture tests, use `pytest-mock`'s `mocker.patch.object(...)` on a real moto-backed STS client. Two viable patterns:
+      1. **Preferred:** Construct the AssumeRoleStrategy, then `mocker.patch("boto3.session.Session.client", wraps=...)` and capture the kwargs from a sentinel side_effect. The wrapped session client still goes through moto so the response shape is realistic.
+      2. **Alternative:** Use `mocker.spy` on `boto3.session.Session.client` to record calls while still allowing the real moto path to run.
+      Choose pattern 1 for the endpoint-URL assertion (need exact kwarg capture); use pattern 2 for the role-arn / session-name assertion against a moto-backed `sts.assume_role` (assert the spy's last call args).
+    - For the ClientError test: under `@mock_aws`, after creating the STS client, `mocker.patch.object(<sts_client>, "assume_role", side_effect=ClientError(...))`. This requires the strategy to expose the sts client OR the patch to happen at a class-level method. Cleaner: patch the `boto3.session.Session.client` factory return value via `mocker.patch.object(boto3.session.Session, "client")` to return a `MagicMock` whose `assume_role` raises. Document the chosen pattern in the test docstring so reviewers can audit.
+    - For the `NoCredentialsError` test: same pattern — patch `assume_role` to raise.
+    - For `test_assume_role_propagates_base_session_token`: wrap `StaticKeysStrategy("a", "b", session_token="T")`, run under `@mock_aws`. moto does NOT validate the session token format for assume_role under `@mock_aws` — it accepts any kwargs and returns a synthetic response. This is the documented behavior in moto 5.2.x.
+
+    Verify: `uv run pytest -m unit -q tests/unit/test_assume_role.py --cov=aws_eks_helm_deploy.auth.assume_role --cov-branch --cov-fail-under=100 --no-header` exits 0.
+
+    Stub call-out:
+    - `ExternalId` is intentionally absent — RESEARCH Section E defers to Phase 4 + IAM template (AUTH-NEXT entry).
+    - `DurationSeconds` is intentionally absent — accept AWS default 3600s.
+    - `MFA` is intentionally absent — out of scope.
+    - These three are documented as comment markers in the source, NOT as TODOs, since they are intentional Phase 2 scope decisions.
+  </action>
+  <verify>
+    <automated>uv run ruff check src tests &amp;&amp; uv run ruff format --check src tests &amp;&amp; uv run mypy --strict src &amp;&amp; uv run pytest -m unit -q tests/unit/test_assume_role.py --cov=aws_eks_helm_deploy.auth.assume_role --cov-branch --cov-fail-under=100 --no-header</automated>
+  </verify>
+  <done>
+    `AssumeRoleStrategy` importable, structurally `AuthStrategy`, calls regional STS endpoint, delegates to base strategy's `get_credentials`, returns `AwsCredentials` with `expiration` set, raises typed errors on STS failures (AuthenticationError for ClientError, ConfigurationError for NoCredentialsError), 100% line+branch coverage on the module, mypy-strict-clean.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| `StaticKeysStrategy` constructor input → `AwsCredentials` | Direct passthrough of consumer-supplied env vars. No validation here — `Settings` already validated via pydantic. |
+| `AssumeRoleStrategy.get_credentials` → STS regional endpoint | Round trip to AWS over TLS. The base strategy's credentials sign the request; STS validates them and returns short-lived credentials with `expiration`. |
+| `assume_role` ClientError → `AuthenticationError` → `pipe.fail()` | The error message contains the STS error code (`AccessDenied`, `InvalidClientTokenId`, etc.) — public values, safe to surface. |
+| Wrapped base strategy → `boto3.Session` kwargs | `creds.to_boto3_kwargs()` returns a dict of credential values that go DIRECTLY into the session constructor — never logged. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-03-01 | Information Disclosure | `AssumeRoleStrategy` error message accidentally includes credential values | mitigate | We construct the error message from `exc.response["Error"]["Code"]` + `exc.response["Error"]["Message"]` — both are AWS-side public values. We do NOT include `exc.response["ResponseMetadata"]` (request ID is informational only) or `self._base.get_credentials()` (never re-fetched at error time). |
+| T-02-03-02 | Tampering | Global STS endpoint silently used instead of regional | mitigate | `endpoint_url=f"https://sts.{self._region}.amazonaws.com"` is hardcoded. There is no fallback path. RESEARCH Section C verified the regional-endpoint requirement. |
+| T-02-03-03 | Elevation of Privilege | `RoleSessionName` is consumer-controlled and could embed unauthorized session metadata | mitigate (delegated) | This strategy trusts its caller (Plan 02-04 `_derive_session_name`) to enforce the AWS 64-char limit and the `[\w+=,.@-]+` regex. Inputs that violate the IAM rule will be rejected by STS itself with a `ValidationError` → mapped to `AuthenticationError`. |
+| T-02-03-04 | Elevation of Privilege | `ROLE_ARN` to unintended account via base credentials | mitigate (delegated) | Trust-policy enforcement is AWS-side (the role's `sts:AssumeRole` trust policy). Our code path makes the call honestly; an unauthorized `RoleArn` → ClientError → AuthenticationError. The IAM trust-policy hardening ships in Phase 4 (AUTH-05). |
+| T-02-03-05 | Repudiation | `assume_role` succeeds but returned credentials are misused later | accept | The `AwsCredentials` carries `expiration`. STS auto-rotates the credentials. We document downstream callers (Plan 02-04 cli wire-in) MUST use them within the 1-hour window. |
+| T-02-03-SC | Tampering | Package legitimacy — `boto3`, `botocore`, `moto[eks,sts]`, `boto3-stubs[eks,sts]` | mitigate | All four are in RESEARCH Section H Package Legitimacy Audit with verdict OK. All already locked in `uv.lock` from Phase 1. ZERO new packages introduced. |
+</threat_model>
+
+<deviations>
+## Documented Deviations from ROADMAP / RESEARCH
+
+### Deviation 1: `RoleSessionName` is taken verbatim by `AssumeRoleStrategy` (no truncation in this module)
+
+**Decision:** The 64-char truncation and `[\w+=,.@-]+` validation per AWS IAM rules happen UPSTREAM in Plan 02-04's `_derive_session_name(settings)` helper. `AssumeRoleStrategy` trusts its caller.
+
+**Rationale:** Single-responsibility — the strategy class concerns itself with the STS round trip, not with naming policy. Naming policy is composition-root concern (Plan 02-04). If the caller violates IAM rules, STS itself returns `ValidationError` → mapped to `AuthenticationError` with a clear message.
+
+**Action item:** None. Documented for the plan-checker so it does not flag the strategy as missing validation.
+
+### Deviation 2: No `DurationSeconds`, no `ExternalId`, no `MFA` in `assume_role` call
+
+**Decision:** All three are intentionally absent from the `assume_role` kwargs.
+
+**Rationale (per RESEARCH Section E):**
+- `DurationSeconds`: accept AWS default of 3600s (1 hour) — more than sufficient for one `helm upgrade --install`.
+- `ExternalId`: deferred to Phase 4 + IAM template work (AUTH-05).
+- `MFA`: out of scope for a CI Pipe.
+
+**Action item:** None. Documented as inline comments in `assume_role.py` so future readers don't think they were forgotten.
+</deviations>
+
+<dependencies_on_prior_plans>
+## Prior Plan Inputs
+
+- **Plan 02-02 (THIS PHASE — wave 1):** `aws_eks_helm_deploy.auth.base.AuthStrategy` Protocol + `AwsCredentials` dataclass with `to_boto3_kwargs()` method. STRICT dependency.
+- **Plan 02-01 (THIS PHASE — wave 1, sibling but not a dependency):** `AssumeRoleStrategy` does NOT import from `aws/eks_token.py`. Listed here for clarity — no source-level coupling.
+- **Phase 1:**
+  - `pyproject.toml`: `boto3 ~= 1.43`, `moto[eks,sts] ~= 5.2`, `boto3-stubs[eks,sts]`, `pytest-mock ~= 3.15` — all installed; ZERO new packages.
+  - `src/aws_eks_helm_deploy/errors.py`: `AuthenticationError` (exit_code=2), `ConfigurationError` (exit_code=1) — reused, NOT extended.
+
+## NOT dependencies
+
+- `aws/eks_token.py` from Plan 02-01 — not consumed by either strategy in this plan.
+- `auth/__init__.py::select_strategy` from Plan 02-04 — not yet implemented.
+</dependencies_on_prior_plans>
+
+<dependencies_on_other_phases>
+## Forward Compatibility
+
+- **Plan 02-04 (composition root):** `select_strategy(settings)` will instantiate `StaticKeysStrategy(...)` and, when `settings.role_arn` is set, wrap it with `AssumeRoleStrategy(static_strategy, role_arn, derived_session_name, settings.aws_region)`. The session name derivation lives there.
+- **Phase 4 (OIDC):** `OidcWebIdentityStrategy` is a peer (not a wrapper) of `StaticKeysStrategy`. The composition root's decision tree gains an OIDC branch — `AssumeRoleStrategy` does NOT need any changes because OIDC's `get_credentials()` returns plain `AwsCredentials` like any other strategy.
+- **Phase 4 + AUTH-05 (IAM trust policy template):** when the IAM template is documented, the `ExternalId` extension hook in this module's source comments becomes the place to wire it in. Until then, the comment serves as a forward-marker.
+
+## Stable contracts (do NOT refactor without bumping major)
+
+```
+class StaticKeysStrategy:
+    def __init__(self, access_key_id: str, secret_access_key: str, session_token: str | None = None) -> None: ...
+    def get_credentials(self) -> AwsCredentials: ...
+
+class AssumeRoleStrategy:
+    def __init__(self, base: AuthStrategy, role_arn: str, session_name: str, region: str) -> None: ...
+    def get_credentials(self) -> AwsCredentials: ...  # raises AuthenticationError / ConfigurationError
+```
+</dependencies_on_other_phases>
+
+<known_stubs>
+## Known Stubs / Scaffolds
+
+- **No code stubs.** Both strategies ship at their final Phase 2 scope.
+- **Documented non-features (intentional, NOT stubs):** `ExternalId`, `DurationSeconds`, `MFA` are absent from `assume_role` kwargs per RESEARCH Section E. Inline comments mark them as out-of-scope.
+- **`RoleSessionName` derivation is NOT in this plan** — Plan 02-04 owns the `_derive_session_name(settings)` helper.
+</known_stubs>
+
+<verification>
+- `uv run ruff check src tests` exits 0.
+- `uv run ruff format --check src tests` exits 0.
+- `uv run mypy --strict src` exits 0.
+- `uv run pytest -m unit -q tests/unit/test_static_keys.py --cov=aws_eks_helm_deploy.auth.static_keys --cov-branch --cov-fail-under=100` exits 0.
+- `uv run pytest -m unit -q tests/unit/test_assume_role.py --cov=aws_eks_helm_deploy.auth.assume_role --cov-branch --cov-fail-under=100` exits 0.
+- `uv run pytest -q` (full unit tier with the 100% gate) exits 0 — no regression in any prior plan's tests.
+- `python -c "from aws_eks_helm_deploy.auth.static_keys import StaticKeysStrategy; from aws_eks_helm_deploy.auth.base import AuthStrategy; assert isinstance(StaticKeysStrategy('a', 'b'), AuthStrategy)"` exits 0.
+- `python -c "from aws_eks_helm_deploy.auth.assume_role import AssumeRoleStrategy; from aws_eks_helm_deploy.auth.base import AuthStrategy; print('OK')"` exits 0.
+</verification>
+
+<success_criteria>
+- AUTH-01: `StaticKeysStrategy` is independent and satisfies the `AuthStrategy` Protocol (per ROADMAP "static_keys.py and assume_role.py are independent classes").
+- AUTH-02: `AssumeRoleStrategy` is independent, composable on top of any base `AuthStrategy` (per ROADMAP "composes `AssumeRoleStrategy` on top of any base strategy").
+- 100% line+branch coverage on both `static_keys.py` AND `assume_role.py`.
+- STS round-trip exercised under `@mock_aws` — both the happy path and both error branches (ClientError, NoCredentialsError) are tested.
+- Regional STS endpoint enforcement is asserted by an `endpoint_url`-capture test.
+- mypy-strict exits 0.
+</success_criteria>
+
+<artifacts>
+## Artifacts this plan produces (Plan 02-03 scope)
+
+**Files (new):**
+- `src/aws_eks_helm_deploy/auth/static_keys.py` — `StaticKeysStrategy` (no AWS calls, pure dataclass wrapper).
+- `src/aws_eks_helm_deploy/auth/assume_role.py` — `AssumeRoleStrategy` (STS round-trip, typed error mapping).
+- `tests/unit/test_static_keys.py` — 7 unit tests.
+- `tests/unit/test_assume_role.py` — 11+ unit tests under `@mock_aws`.
+
+**New Python symbols (importable):**
+- `aws_eks_helm_deploy.auth.static_keys.StaticKeysStrategy(access_key_id, secret_access_key, session_token=None)`.
+- `aws_eks_helm_deploy.auth.assume_role.AssumeRoleStrategy(base, role_arn, session_name, region)`.
+
+**Stubs (explicitly called out):**
+- None — both strategies ship at final Phase 2 behavior.
+
+**Out of scope for this plan:**
+- `select_strategy()` composition root (Plan 02-04).
+- `_derive_session_name(settings)` helper (Plan 02-04).
+- OIDC strategy (Phase 4).
+- `ExternalId` / `DurationSeconds` / `MFA` on `assume_role` (Phase 4 / out of scope).
+- CLI wire-in (Plan 02-04).
+</artifacts>
+
+<output>
+On completion, create `.planning/phases/02-aws-layer-auth-foundation/02-03-SUMMARY.md` recording:
+- Final coverage % on `static_keys.py` AND `assume_role.py` (must be 100% each).
+- Which mocking pattern was chosen for the kwarg-capture tests (pattern 1 vs pattern 2 from the action block).
+- Whether the moto `@mock_aws` happy path returned a non-None `expiration` (it should — moto 5.2.x produces a synthetic STS response with a datetime).
+- Confirmation that the `endpoint_url` assertion test passed (no global-endpoint regression).
+- The exact `mypy_boto3_sts` version observed for ADR Phase 7 traceability.
+- Re-statement of the three documented non-features (`ExternalId`, `DurationSeconds`, `MFA` absent — by design).
+</output>

--- a/.planning/phases/02-aws-layer-auth-foundation/02-04-PLAN.md
+++ b/.planning/phases/02-aws-layer-auth-foundation/02-04-PLAN.md
@@ -1,0 +1,573 @@
+---
+phase: 02-aws-layer-auth-foundation
+plan: 4
+type: execute
+wave: 3
+depends_on:
+  - "02-01"
+  - "02-02"
+  - "02-03"
+files_modified:
+  - src/aws_eks_helm_deploy/auth/__init__.py
+  - src/aws_eks_helm_deploy/cli.py
+  - tests/unit/test_auth_select.py
+  - tests/unit/test_cli.py
+  - tests/integration/test_auth_smoke.py
+autonomous: true
+requirements:
+  - AUTH-01
+  - AUTH-02
+  - AUTH-07
+tags:
+  - auth
+  - composition
+  - cli
+  - integration
+  - session-name
+
+must_haves:
+  truths:
+    - "`from aws_eks_helm_deploy.auth import select_strategy` resolves to a callable with signature `(settings: Settings) -> AuthStrategy`."
+    - "`select_strategy(settings)` returns `StaticKeysStrategy` when only `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` are set; returns `AssumeRoleStrategy` (wrapping `StaticKeysStrategy`) when `ROLE_ARN` is ALSO set."
+    - "`select_strategy(settings)` raises `ConfigurationError` (exit_code=1) with a clear message when `ROLE_ARN` is set without base credentials (OIDC-base-via-Phase-4 hint included)."
+    - "`select_strategy(settings)` raises `ConfigurationError` when NO credentials are configured (no static keys, no `ROLE_ARN`)."
+    - "`AWS_SESSION_TOKEN` is propagated through `StaticKeysStrategy` to the base credentials and onward to `AssumeRoleStrategy` when both `ROLE_ARN` and `AWS_SESSION_TOKEN` are set."
+    - "The derived `RoleSessionName` is at most 64 characters AND matches the AWS IAM character class `[\\w+=,.@-]+`."
+    - "`cli.main()` calls `select_strategy(settings)` BEFORE any action dispatch; on `ConfigurationError` it surfaces via `pipe.fail()` and returns exit code 1; the structlog context is populated with `auth_strategy=<class name>` via `bind_safe_context` BEFORE the strategy is invoked."
+    - "Credential values are NEVER passed into `bind_safe_context` (the contract from Plan 02-02 holds: the test would raise `ValueError`)."
+    - "An integration test on a `kind` cluster proves the end-to-end shape: `StaticKeysStrategy` → `boto3.Session` → `generate_eks_token(session, cluster_name, region)` produces a structurally valid `k8s-aws-v1.` token under non-cluster-network conditions (the token is shape-checked; real EKS webhook validation is out of scope per RESEARCH Section G)."
+    - "`mypy --strict src` exits 0 with the wire-in."
+    - "Coverage on `auth/__init__.py` AND on the new `cli.py` branches is 100% line + branch."
+  artifacts:
+    - path: "src/aws_eks_helm_deploy/auth/__init__.py"
+      provides: "`select_strategy(settings)` composition root + `_derive_session_name(settings)` helper. Public re-exports of `AuthStrategy`, `AwsCredentials`, `StaticKeysStrategy`, `AssumeRoleStrategy`, `select_strategy`."
+      contains: "def select_strategy"
+      min_lines: 60
+    - path: "src/aws_eks_helm_deploy/cli.py"
+      provides: "Extended with `select_strategy(settings)` call after `configure_logging`; binds `auth_strategy` to structlog context; surfaces `ConfigurationError` via existing PipeError handler."
+      contains: "auth_strategy=type(strategy).__name__"
+    - path: "tests/unit/test_auth_select.py"
+      provides: "Unit tests for all four decision-tree branches + `_derive_session_name` helper + `AWS_SESSION_TOKEN` propagation."
+      contains: "select_strategy"
+      min_lines: 100
+    - path: "tests/unit/test_cli.py"
+      provides: "Extended with cli-level test that `select_strategy` is called between `configure_logging` and the action dispatch; `ConfigurationError` from select_strategy returns exit code 1 with `pipe.fail` called."
+      contains: "select_strategy"
+    - path: "tests/integration/test_auth_smoke.py"
+      provides: "Two integration tests: (1) StaticKeysStrategy → AwsCredentials shape; (2) end-to-end EKS token generation against a kind cluster name (token shape only — no real EKS webhook)."
+      contains: "@pytest.mark.integration"
+      min_lines: 50
+  key_links:
+    - from: "src/aws_eks_helm_deploy/auth/__init__.py::select_strategy"
+      to: "src/aws_eks_helm_deploy/auth/static_keys.py::StaticKeysStrategy"
+      via: "instantiation when AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY present"
+      pattern: "StaticKeysStrategy\\("
+    - from: "src/aws_eks_helm_deploy/auth/__init__.py::select_strategy"
+      to: "src/aws_eks_helm_deploy/auth/assume_role.py::AssumeRoleStrategy"
+      via: "wraps base strategy when ROLE_ARN set"
+      pattern: "AssumeRoleStrategy\\("
+    - from: "src/aws_eks_helm_deploy/auth/__init__.py::select_strategy"
+      to: "src/aws_eks_helm_deploy/errors.py::ConfigurationError"
+      via: "raise ConfigurationError on misconfiguration"
+      pattern: "raise ConfigurationError"
+    - from: "src/aws_eks_helm_deploy/cli.py"
+      to: "src/aws_eks_helm_deploy/auth/__init__.py::select_strategy"
+      via: "strategy = select_strategy(settings)"
+      pattern: "select_strategy\\(settings\\)"
+    - from: "src/aws_eks_helm_deploy/cli.py"
+      to: "src/aws_eks_helm_deploy/logging.py::bind_safe_context"
+      via: "bind_safe_context(auth_strategy=type(strategy).__name__)"
+      pattern: "bind_safe_context\\(auth_strategy="
+    - from: "tests/integration/test_auth_smoke.py"
+      to: "src/aws_eks_helm_deploy/aws/eks_token.py::generate_eks_token"
+      via: "end-to-end token shape verification"
+      pattern: "generate_eks_token"
+---
+
+<objective>
+Compose the Phase 2 pieces into a working pipe path: `select_strategy(settings)` chooses between `StaticKeysStrategy` and `AssumeRoleStrategy(base, ...)`, `cli.main()` calls it between `configure_logging` and the placeholder action dispatch, and an integration test proves the end-to-end shape (Settings → strategy → credentials → boto3.Session → `generate_eks_token` → structurally valid `k8s-aws-v1.` token). After this plan, AUTH-01 + AUTH-02 + AUTH-07 are fully wired end-to-end against the Phase 1 skeleton.
+
+Purpose: Closes the AUTH-01 composition-root half ("`auth/__init__.py::select_strategy(settings)` composes `AssumeRoleStrategy` on top of any base strategy"), AUTH-02 full (composability), and the AUTH-07 end-to-end wire (token generation from a strategy-supplied session). This is the LAST plan in Phase 2; after it merges, Phase 2 ships.
+
+Output:
+- `src/aws_eks_helm_deploy/auth/__init__.py` — `select_strategy(settings)` + `_derive_session_name(settings)` + public re-exports.
+- `src/aws_eks_helm_deploy/cli.py` — extended with `select_strategy(settings)` call + structlog `auth_strategy` context bind.
+- `tests/unit/test_auth_select.py` — full decision-tree coverage.
+- `tests/unit/test_cli.py` — extended with the strategy wire-in test (modify existing file from Phase 1).
+- `tests/integration/test_auth_smoke.py` — end-to-end shape verification.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md
+@.planning/phases/02-aws-layer-auth-foundation/02-01-PLAN.md
+@.planning/phases/02-aws-layer-auth-foundation/02-02-PLAN.md
+@.planning/phases/02-aws-layer-auth-foundation/02-03-PLAN.md
+@src/aws_eks_helm_deploy/settings.py
+@src/aws_eks_helm_deploy/cli.py
+@src/aws_eks_helm_deploy/logging.py
+@src/aws_eks_helm_deploy/errors.py
+@tests/unit/test_cli.py
+@tests/integration/conftest.py
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 02-4-01: select_strategy() composition root + _derive_session_name() helper</name>
+  <files>src/aws_eks_helm_deploy/auth/__init__.py, tests/unit/test_auth_select.py</files>
+  <read_first>
+    - .planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md (Section E — full decision tree pseudocode, `_derive_session_name` algorithm, AWS 64-char limit, regex `[\\w+=,.@-]+`)
+    - src/aws_eks_helm_deploy/auth/base.py (after Plan 02-02 merges — AuthStrategy + AwsCredentials available)
+    - src/aws_eks_helm_deploy/auth/static_keys.py (after Plan 02-03 — `StaticKeysStrategy(access_key_id, secret_access_key, session_token=None)`)
+    - src/aws_eks_helm_deploy/auth/assume_role.py (after Plan 02-03 — `AssumeRoleStrategy(base, role_arn, session_name, region)`)
+    - src/aws_eks_helm_deploy/settings.py (Settings fields: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `role_arn`, `session_name`, `aws_region`. NOTE: the Phase 1 Settings does NOT yet have an `aws_session_token` field — confirm by reading the file. If absent, this task ADDS it.)
+    - src/aws_eks_helm_deploy/errors.py (ConfigurationError exit_code=1 — reused; no new error types)
+  </read_first>
+  <behavior>
+    Settings extension check (precondition):
+    - The Plan 1 `Settings` model (in `src/aws_eks_helm_deploy/settings.py`) MAY already declare an `aws_session_token: str | None = Field(default=None, alias="AWS_SESSION_TOKEN")` field. If it does, no change needed.
+    - If NOT declared, this task adds the field to `Settings` (one-line insertion next to `aws_secret_access_key`). The orchestrator was warned via the phase context block that the field already exists per the planner's pre-flight read — so this should be a NO-OP in practice. If the read reveals it's missing, ADD it.
+    - This is the ONLY mutation of `settings.py` in Phase 2.
+
+    Module `src/aws_eks_helm_deploy/auth/__init__.py` becomes:
+    - Module docstring with AUTH-01 + AUTH-02 traceability + a brief decision-tree pseudocode for grepability.
+    - `from __future__ import annotations`.
+    - imports: `import os`, `import re`, `import uuid`, `from typing import TYPE_CHECKING`, conditional re-exports from `.base`, `.static_keys`, `.assume_role`. Use `TYPE_CHECKING` block ONLY for `Settings` (to avoid circular import between `auth/` and `settings.py`).
+    - Public re-exports via `__all__: list[str] = ["AuthStrategy", "AwsCredentials", "StaticKeysStrategy", "AssumeRoleStrategy", "select_strategy"]`.
+    - Module-level constant `_DEFAULT_SESSION_NAME: Final[str] = "BitbucketPipe"` — matches `Settings.session_name` default. Use this as the sentinel to detect "user did not explicitly set SESSION_NAME".
+    - Module-level constant `_SESSION_NAME_MAX_LEN: Final[int] = 64`.
+    - Module-level constant `_SESSION_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(r"[\\w+=,.@-]+")` — the AWS IAM character class for `RoleSessionName`.
+
+    Function `_derive_session_name(settings: Settings) -> str` per RESEARCH Section E:
+    1. If `settings.session_name != _DEFAULT_SESSION_NAME`: return `settings.session_name[:_SESSION_NAME_MAX_LEN]` (consumer explicitly set it — honor it, but enforce the 64-char limit defensively).
+    2. Else, try `BITBUCKET_PIPELINE_UUID` env var: if set, strip surrounding braces `{...}`, prepend `aws-eks-helm-deploy-`, truncate to 64 chars.
+    3. Else, try `BITBUCKET_BUILD_NUMBER` env var: if set, prepend `aws-eks-helm-deploy-`, truncate to 64 chars.
+    4. Else, return `f"aws-eks-helm-deploy-{uuid.uuid4()}"` truncated to 64 chars.
+    5. Validation: the returned value MUST match `_SESSION_NAME_PATTERN.fullmatch`. UUIDs and BB build numbers always do; consumer-supplied values MIGHT not. If it doesn't, fall through to step 4 (UUID).
+    NOTE: reading `os.environ` inside `auth/__init__.py` is ALLOWED for this Bitbucket-supplied envar lookup — the rule in Phase 1 PATTERNS.md ("never call `os.environ.get` outside `settings.py`") applies to pipe-consumer-controlled vars. `BITBUCKET_PIPELINE_UUID` is platform-supplied (Bitbucket runner sets it) and is NOT in the pipe's documented `pipe.yml` schema. Documenting the lookup as a one-shot side-channel here is the pragmatic path; a follow-up (Phase 2.1) could promote them into Settings if needed.
+
+    Function `select_strategy(settings: Settings) -> AuthStrategy` per RESEARCH Section E decision tree:
+    ```
+    # Phase 4: insert OIDC check here  ←  reserved comment for forward-marker
+    if settings.aws_access_key_id and settings.aws_secret_access_key:
+        base = StaticKeysStrategy(
+            settings.aws_access_key_id,
+            settings.aws_secret_access_key,
+            settings.aws_session_token,  # may be None
+        )
+        if settings.role_arn:
+            session_name = _derive_session_name(settings)
+            return AssumeRoleStrategy(base, settings.role_arn, session_name, settings.aws_region)
+        return base
+
+    if settings.role_arn:
+        raise ConfigurationError(
+            "ROLE_ARN requires AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY "
+            "(OIDC-based role assumption ships in Phase 4)"
+        )
+
+    raise ConfigurationError(
+        "No valid credential configuration: set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY"
+    )
+    ```
+    The Phase 4 forward-marker comment is mandatory — Plan 4 of Phase 4 will replace it with the OIDC check.
+
+    Test list (`tests/unit/test_auth_select.py`, all `@pytest.mark.unit`):
+    - `test_select_static_keys_only` — set `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` via monkeypatch, `Settings()`, `select_strategy(settings)` returns a `StaticKeysStrategy` instance (assert `isinstance(s, StaticKeysStrategy)`); calling `.get_credentials()` returns an `AwsCredentials` with the expected values.
+    - `test_select_static_keys_plus_role_arn_returns_assume_role` — also set `ROLE_ARN`; `select_strategy` returns `AssumeRoleStrategy`; the base inside (private attr access for the test) is a `StaticKeysStrategy`.
+    - `test_select_role_arn_without_base_raises_configuration_error` — set `ROLE_ARN` only; `select_strategy` raises `ConfigurationError` with exit_code=1 AND the error message contains the substring "Phase 4" (forward-pointer hint).
+    - `test_select_no_credentials_raises_configuration_error` — empty env; raise; message contains "AWS_ACCESS_KEY_ID".
+    - `test_select_with_aws_session_token_passes_through` — set keys + `AWS_SESSION_TOKEN`; the returned `StaticKeysStrategy` propagates `session_token`; `creds.session_token` reflects it.
+    - `test_select_with_session_token_and_role_arn` — set keys + session token + ROLE_ARN; returns `AssumeRoleStrategy` wrapping a `StaticKeysStrategy` that itself has `session_token` set.
+    - `test_derive_session_name_explicit_session_name_honored` — `SESSION_NAME=custom-name`; helper returns `"custom-name"`.
+    - `test_derive_session_name_explicit_session_name_truncated_to_64` — pass a 80-char SESSION_NAME, assert returned string is exactly 64 chars.
+    - `test_derive_session_name_bitbucket_pipeline_uuid_used_when_default` — leave SESSION_NAME at default; set `BITBUCKET_PIPELINE_UUID={1234-5678-...}`; returned name starts with `aws-eks-helm-deploy-1234-5678-`.
+    - `test_derive_session_name_bitbucket_pipeline_uuid_strips_braces` — set `BITBUCKET_PIPELINE_UUID={abc}`; assert `"{"` and `"}"` not in returned name.
+    - `test_derive_session_name_bitbucket_build_number_used_as_fallback` — leave PIPELINE_UUID unset; set `BITBUCKET_BUILD_NUMBER=42`; returned name is `aws-eks-helm-deploy-42`.
+    - `test_derive_session_name_uuid_fallback` — leave both BB envars unset; assert the returned name starts with `aws-eks-helm-deploy-` and the suffix is a UUID4 string (matches `[0-9a-f-]+`).
+    - `test_derive_session_name_truncated_to_64_chars` — verify total length is `<= 64` in all four code paths.
+    - `test_derive_session_name_matches_iam_pattern` — assert `re.fullmatch(r"[\\w+=,.@-]+", derived_name) is not None` for ALL four paths.
+    - `test_derive_session_name_explicit_session_name_invalid_chars_falls_through_to_uuid` — set `SESSION_NAME="has spaces"` (invalid per IAM pattern); helper returns a UUID-based fallback. NOTE: this branch may be excluded from Phase 2 scope IF the alternative is to raise — decision: silently fall through to UUID (RESEARCH Section E "verify the value matches `[\\w+=,.@-]+` — UUIDs always do, consumer values MIGHT not"). Document in test docstring that this is the intentional graceful-degradation choice.
+
+    Coverage target: 100% line + 100% branch on `auth/__init__.py`.
+  </behavior>
+  <action>
+    First, verify Phase 1 Settings has `aws_session_token`. Read `src/aws_eks_helm_deploy/settings.py` line range covering the AWS-credentials fields block. If the field is absent (planner's read confirmed it IS present at line 88, but the executor verifies again), insert it:
+    ```python
+    aws_session_token: str | None = Field(default=None, alias="AWS_SESSION_TOKEN")
+    ```
+    Place it after `aws_secret_access_key` and before `role_arn`. If the field is already present, do nothing to `settings.py`.
+
+    [Planner note: at planning time, `settings.py` line 87–89 show `aws_access_key_id`, `aws_secret_access_key`, `role_arn` — `aws_session_token` is NOT yet declared. The executor MUST add it. Re-verify by reading the file before the change.]
+
+    Create `src/aws_eks_helm_deploy/auth/__init__.py` REPLACING the empty Plan 02-02 placeholder:
+    - Module docstring with AUTH-01 + AUTH-02 traceability.
+    - `from __future__ import annotations`.
+    - Imports per the behavior contract.
+    - `TYPE_CHECKING` block for `Settings`:
+      ```python
+      if TYPE_CHECKING:
+          from aws_eks_helm_deploy.settings import Settings
+      ```
+    - Re-exports from `.base`, `.static_keys`, `.assume_role`:
+      ```python
+      from aws_eks_helm_deploy.auth.base import AuthStrategy, AwsCredentials
+      from aws_eks_helm_deploy.auth.static_keys import StaticKeysStrategy
+      from aws_eks_helm_deploy.auth.assume_role import AssumeRoleStrategy
+      ```
+    - Import `ConfigurationError` from `aws_eks_helm_deploy.errors`.
+    - Module-level constants `_DEFAULT_SESSION_NAME`, `_SESSION_NAME_MAX_LEN`, `_SESSION_NAME_PATTERN`.
+    - `_derive_session_name(settings: Settings) -> str` per the algorithm above; include a docstring explaining the four-step fallback chain.
+    - `select_strategy(settings: Settings) -> AuthStrategy` per the decision tree above; include a docstring listing the four outcomes (StaticKeys / AssumeRole-on-Static / ConfigError-no-base / ConfigError-no-creds) AND the `# Phase 4: insert OIDC check here` forward-marker comment ABOVE the static-keys branch.
+    - `__all__` published as listed above.
+    - mypy-strict-clean.
+
+    Create `tests/unit/test_auth_select.py` per the behavior list:
+    - Module docstring referencing AUTH-01 + AUTH-02.
+    - `from __future__ import annotations`.
+    - imports: `re`, `pytest`, `from aws_eks_helm_deploy.auth import select_strategy, _derive_session_name`, `from aws_eks_helm_deploy.auth.base import AuthStrategy, AwsCredentials`, `from aws_eks_helm_deploy.auth.static_keys import StaticKeysStrategy`, `from aws_eks_helm_deploy.auth.assume_role import AssumeRoleStrategy`, `from aws_eks_helm_deploy.errors import ConfigurationError`, `from aws_eks_helm_deploy.settings import Settings`.
+    - All 14 tests as listed.
+    - Each test uses `monkeypatch.delenv` for ALL credential-related env vars at setup (to ensure isolation from a developer's shell), then sets only what each scenario needs. Pattern:
+      ```python
+      @pytest.fixture(autouse=True)
+      def _clean_aws_env(monkeypatch: pytest.MonkeyPatch) -> None:
+          for var in (
+              "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+              "ROLE_ARN", "SESSION_NAME", "BITBUCKET_PIPELINE_UUID", "BITBUCKET_BUILD_NUMBER",
+          ):
+              monkeypatch.delenv(var, raising=False)
+      ```
+    - For the `_derive_session_name` tests, instantiate `Settings()` (with appropriate monkeypatched envars) and pass it as the helper argument.
+    - For the private-attr access in `test_select_static_keys_plus_role_arn_returns_assume_role` (asserting the base inside the AssumeRoleStrategy is a StaticKeysStrategy), access `strategy._base` and assert `isinstance(strategy._base, StaticKeysStrategy)`. Mark in the test docstring that this private attribute access is intentional — Phase 2 has no public introspection API for the wrapped base.
+
+    Verify: `uv run pytest -m unit -q tests/unit/test_auth_select.py --cov=aws_eks_helm_deploy.auth --cov-branch --cov-fail-under=100 --no-header` exits 0. (Note: `--cov=aws_eks_helm_deploy.auth` covers the package including `__init__.py`; previous plans' `base.py`/`static_keys.py`/`assume_role.py` will not regress since their own tests are still active.)
+
+    Stub call-out:
+    - `# Phase 4: insert OIDC check here` is a comment placeholder, NOT a code stub.
+    - `BITBUCKET_PIPELINE_UUID` / `BITBUCKET_BUILD_NUMBER` are read via `os.environ` — this is a documented one-shot deviation from the "no `os.environ` outside `settings.py`" rule (justified because these are platform-supplied, not consumer-supplied per `pipe.yml`).
+  </action>
+  <verify>
+    <automated>uv run ruff check src tests &amp;&amp; uv run ruff format --check src tests &amp;&amp; uv run mypy --strict src &amp;&amp; uv run pytest -m unit -q tests/unit/test_auth_select.py --cov=aws_eks_helm_deploy.auth --cov-branch --cov-fail-under=100 --no-header</automated>
+  </verify>
+  <done>
+    `select_strategy(settings)` returns the right strategy for all four decision branches; `_derive_session_name` produces session names that satisfy AWS IAM rules (<=64 chars, `[\\w+=,.@-]+`); 100% line+branch coverage on `auth/__init__.py`; mypy-strict-clean; the existing 33+ Phase 1 unit tests AND the Plans 02-01/02/03 unit tests still pass.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 02-4-02: cli.py wire-in + structlog auth_strategy context bind</name>
+  <files>src/aws_eks_helm_deploy/cli.py, tests/unit/test_cli.py</files>
+  <read_first>
+    - src/aws_eks_helm_deploy/cli.py (existing Phase 1 placeholder — read FULL file before editing; we EXTEND, we do NOT rewrite)
+    - src/aws_eks_helm_deploy/logging.py (CREDENTIAL_BLOCKLIST + bind_safe_context contract from Phase 1; STABLE_FIELDS tuple includes `auth_strategy`)
+    - src/aws_eks_helm_deploy/auth/__init__.py (after Task 02-4-01 merges)
+    - tests/unit/test_cli.py (existing Phase 1 test file — read FULL file, we ADD tests, we do NOT delete existing tests)
+    - .planning/phases/01-toolchain-spine/01-VERIFICATION.md (SC5 PARTIAL note — `cli.py` currently has NO `structlog.info` call; this task closes that gap by adding the `bind_safe_context(auth_strategy=...)` call)
+  </read_first>
+  <behavior>
+    Modified `src/aws_eks_helm_deploy/cli.py`:
+    - Imports add: `from aws_eks_helm_deploy.auth import select_strategy`, `from aws_eks_helm_deploy.logging import bind_safe_context, get_logger`.
+    - Inside `main(argv)`, AFTER `configure_logging(settings)` and BEFORE `pipe = PipeIO()`:
+      ```python
+      try:
+          strategy = select_strategy(settings)
+      except PipeError as exc:
+          # Settings already validated; this is a documented misconfiguration.
+          pipe = PipeIO()
+          pipe.fail(exc.user_message)
+          return exc.exit_code
+      bind_safe_context(auth_strategy=type(strategy).__name__)
+      logger = get_logger(__name__)
+      logger.info("auth strategy selected", auth_strategy=type(strategy).__name__)
+      ```
+    - The existing `pipe = PipeIO()` line moves to AFTER the strategy selection succeeded (so failure path can still construct a PipeIO for `pipe.fail`).
+    - Phase 1 PARTIAL gap (SC5: no `structlog.info` call at runtime) is CLOSED by the `logger.info("auth strategy selected", ...)` call — `LOG_FORMAT=json docker run ...` now emits one parseable JSON line on stderr.
+    - The existing placeholder success message `pipe.success("Phase 1 skeleton — no action executed")` becomes `pipe.success("Phase 2 skeleton — auth strategy selected; action dispatch lands in Phase 3+")`. The exit code 0 stays.
+    - Behavior on `ConfigurationError`: surface via `pipe.fail()`, return exit code 1.
+    - Behavior on Settings-load error (existing Phase 1 path): unchanged — `sys.stderr.write` + return 1.
+    - Behavior on bare `Exception` (existing Phase 1 path): unchanged — `pipe.fail("Unexpected error — see logs")` + return 99.
+
+    Extended `tests/unit/test_cli.py` (add NEW tests; do NOT delete or modify existing tests):
+    - `test_main_selects_static_keys_strategy` — monkeypatch valid env vars, call `main([])`; assert exit 0; assert a logger.info call happened with `auth_strategy="StaticKeysStrategy"` (use `caplog` fixture configured for structlog, OR `mocker.patch("aws_eks_helm_deploy.cli.get_logger")` to capture the call).
+    - `test_main_selects_assume_role_strategy` — set keys + ROLE_ARN; assert exit 0; assert `auth_strategy="AssumeRoleStrategy"`.
+    - `test_main_configuration_error_from_select_strategy_returns_1` — empty env; assert `main([]) == 1`; mock `PipeIO.fail` to capture the call args (or use mocker to patch `aws_eks_helm_deploy.cli.PipeIO`) and assert `pipe.fail` was called with the configuration-error message.
+    - `test_main_bind_safe_context_called_with_auth_strategy` — monkeypatch keys; `mocker.patch("aws_eks_helm_deploy.cli.bind_safe_context")`; call `main([])`; assert `bind_safe_context` was called with kwarg `auth_strategy="StaticKeysStrategy"`.
+    - `test_main_credentials_never_passed_to_bind_safe_context` — `mocker.patch("aws_eks_helm_deploy.cli.bind_safe_context")`; call `main([])`; assert the captured call kwargs contain NO credential keys (`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`).
+    - Existing Phase 1 tests (`test_main_placeholder_success`, `test_main_catches_pipe_error`, `test_main_catches_bare_exception`, `test_main_module_runs`) MUST continue to pass — the new path constructs a strategy first, so existing tests need to monkeypatch valid env vars (use a fixture similar to Task 02-4-01's `_clean_aws_env` but PROVIDING test creds). UPDATE the existing tests to either: (a) provide creds via monkeypatch so the strategy selection succeeds and the placeholder success path still runs, OR (b) explicitly patch `select_strategy` to return a mock strategy that doesn't perform any AWS round-trip.
+    - Pick option (b) for the Phase-1-style tests to keep them focused on cli flow, not auth env-var coverage. Add a fixture:
+      ```python
+      @pytest.fixture
+      def _fake_strategy(mocker: pytest_mock.MockerFixture) -> object:
+          fake = mocker.MagicMock(spec=AuthStrategy)
+          mocker.patch("aws_eks_helm_deploy.cli.select_strategy", return_value=fake)
+          return fake
+      ```
+      Existing `test_main_placeholder_success` becomes `def test_main_placeholder_success(_fake_strategy: object) -> None:` to short-circuit auth.
+
+    Coverage target: 100% line + branch on `cli.py` (including the new strategy-selection block). The `except PipeError` branch on `select_strategy` MUST be exercised — `test_main_configuration_error_from_select_strategy_returns_1` covers this.
+  </behavior>
+  <action>
+    Read `src/aws_eks_helm_deploy/cli.py` FRESH (executor must run Read at the top of this task — file is small, ~50 lines).
+
+    Edit `cli.py`:
+    - Add the two new imports at the top (preserve import order — `aws_eks_helm_deploy.auth` is a sibling of `aws_eks_helm_deploy.logging` and `.errors`).
+    - Restructure `main()` per the behavior contract:
+      1. Existing `try: settings = Settings()` block — unchanged.
+      2. `configure_logging(settings)` — unchanged.
+      3. NEW: `try: strategy = select_strategy(settings)` block with PipeError handler.
+      4. NEW: `bind_safe_context(auth_strategy=type(strategy).__name__)`.
+      5. NEW: `logger = get_logger(__name__); logger.info("auth strategy selected", auth_strategy=type(strategy).__name__)`.
+      6. `pipe = PipeIO()` — moves to AFTER step 4 (so the `select_strategy` failure path constructs its own local `PipeIO`).
+      7. Inner `try/except PipeError/except Exception` block on the placeholder action — unchanged in structure; the success message text updates per the behavior contract.
+    - The `# noqa: BLE001` on `except Exception` stays.
+    - The bottom-of-file `if __name__ == "__main__": sys.exit(main())` stays (with `# pragma: no cover`).
+
+    Edit `tests/unit/test_cli.py`:
+    - Read full existing file first.
+    - Add new imports for the new tests (`pytest_mock`, the strategy classes, `bind_safe_context`, etc.).
+    - Add the `_fake_strategy` fixture.
+    - Add the FIVE new tests per the behavior contract.
+    - Update the existing four Phase 1 tests to use `_fake_strategy` (or provide creds via monkeypatch). Choose `_fake_strategy` for simplicity — these tests should exercise cli flow, not auth env vars.
+    - Verify ALL tests in `test_cli.py` (existing 4 + new 5 = 9 total) still pass.
+
+    Verify: `uv run pytest -m unit -q tests/unit/test_cli.py --cov=aws_eks_helm_deploy.cli --cov-branch --cov-fail-under=100 --no-header && uv run pytest -q` (full suite — no regression).
+
+    Stub call-out:
+    - The placeholder success message STILL exists; Phase 3 replaces it with real ACTION dispatch.
+    - `cli.main()` calls `strategy.get_credentials()` NEVER in Phase 2 — the strategy is selected but NOT INVOKED. This is intentional: Phase 2 ships the wiring; Phase 3+ adds the action dispatch that actually calls `strategy.get_credentials()`, builds the boto3 session, and calls `generate_eks_token`. Calling `.get_credentials()` here would make Phase 2 do real AWS calls every time the pipe runs even without an action — that's wrong scope.
+  </action>
+  <verify>
+    <automated>uv run ruff check src tests &amp;&amp; uv run mypy --strict src &amp;&amp; uv run pytest -m unit -q tests/unit/test_cli.py --cov=aws_eks_helm_deploy.cli --cov-branch --cov-fail-under=100 --no-header &amp;&amp; uv run pytest -q</automated>
+  </verify>
+  <done>
+    `cli.main()` calls `select_strategy(settings)` between `configure_logging` and the placeholder action; `bind_safe_context(auth_strategy=...)` is called with the strategy class name; `logger.info` emits one structlog line at runtime (closes Phase 1 OBS-01 PARTIAL gap); ConfigurationError from `select_strategy` returns exit code 1; existing Phase 1 cli tests still pass via the `_fake_strategy` fixture; full unit suite green at 100% line+branch.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 02-4-03: Integration smoke test — end-to-end auth → boto3.Session → eks_token shape</name>
+  <files>tests/integration/test_auth_smoke.py</files>
+  <read_first>
+    - .planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md (Section G "Integration Tests (kind cluster)" — full scope and limitations of kind-based integration testing for EKS auth)
+    - tests/integration/conftest.py (existing Phase 1 `kind_cluster` fixture — `scope="session"`, skips when kind/helm absent, yields cluster name string)
+    - tests/integration/test_helm_smoke.py (existing Phase 1 integration test — for style reference)
+    - src/aws_eks_helm_deploy/aws/eks_token.py (after Plan 02-01 merges — generate_eks_token signature)
+    - src/aws_eks_helm_deploy/auth/__init__.py (after Task 02-4-01 merges — select_strategy signature)
+  </read_first>
+  <behavior>
+    Module `tests/integration/test_auth_smoke.py` exposes two `@pytest.mark.integration` tests:
+
+    Test 1 — `test_static_keys_produce_credentials`:
+    - Does NOT use the `kind_cluster` fixture (this test does not need a real cluster — kind is overkill here).
+    - Monkeypatch `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to fixture values.
+    - Instantiate `Settings()`.
+    - Call `select_strategy(settings)`; assert it returns a `StaticKeysStrategy`.
+    - Call `strategy.get_credentials()`; assert `creds.access_key_id == "AKIAIOSFODNN7EXAMPLE"`.
+    - Assert `"secret" not in repr(creds)` (Phase 2 contract crossover — verifies the repr-masking integration).
+    - This test proves the end-to-end Settings → select_strategy → AwsCredentials shape without any AWS calls.
+
+    Test 2 — `test_eks_token_is_structurally_valid`:
+    - Uses the `kind_cluster` fixture (session-scoped, comes from `tests/integration/conftest.py`).
+    - Monkeypatch `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` to fixture values.
+    - Build a `boto3.Session` directly (skip `select_strategy` here to isolate the token-generation surface): `session = boto3.Session(region_name="eu-central-1", aws_access_key_id="AKIAIOSFODNN7EXAMPLE", aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")`.
+    - Call `token = generate_eks_token(session, kind_cluster, "eu-central-1")`.
+    - Assert `token.startswith("k8s-aws-v1.")`.
+    - Assert `"=" not in token` (no base64 padding).
+    - Base64url-decode the payload (add `=` padding back), parse the URL query string, assert `X-Amz-Expires=60`, `"x-k8s-aws-id" in X-Amz-SignedHeaders`, and the hostname is `sts.eu-central-1.amazonaws.com`.
+    - This test runs WITHOUT `@mock_aws` — it uses real botocore signing against (non-routable) AWS endpoints, but the token is only EVALUATED for shape, NEVER sent over the wire. RESEARCH Section G "What kind cannot test" — real EKS webhook validation is explicitly out of scope.
+
+    The integration tier does NOT need to invoke the kind cluster's kube-apiserver — the `kind_cluster` fixture is only used to supply a realistic cluster-name string (and to gate the test as "integration tier"). The whole test runs in-process; the kind cluster's only role is being NAMED.
+
+    Both tests skip cleanly when the underlying tooling is missing (the `kind_cluster` fixture already skips when kind/helm absent; Test 1 only needs pure Python).
+
+    Tier discipline: NO `--cov` measurement on integration tests (Plan 01-02-PLAN: integration tier opts out of the 100% gate with `--no-cov`). The unit tests already cover `select_strategy` and `generate_eks_token` to 100%.
+  </behavior>
+  <action>
+    Create `tests/integration/test_auth_smoke.py`:
+    - Module docstring: "Phase 2 integration smoke — end-to-end auth wire-in shape verification on a kind cluster. Real EKS webhook validation is out of scope per RESEARCH Section G."
+    - `from __future__ import annotations`.
+    - imports: `base64`, `urllib.parse`, `pytest`, `boto3`, `from aws_eks_helm_deploy.auth import select_strategy`, `from aws_eks_helm_deploy.auth.static_keys import StaticKeysStrategy`, `from aws_eks_helm_deploy.aws.eks_token import generate_eks_token`, `from aws_eks_helm_deploy.settings import Settings`.
+    - Two test functions:
+      1. `def test_static_keys_produce_credentials(monkeypatch: pytest.MonkeyPatch) -> None:` decorated with `@pytest.mark.integration`. Body per Test 1 behavior.
+      2. `def test_eks_token_is_structurally_valid(kind_cluster: str, monkeypatch: pytest.MonkeyPatch) -> None:` decorated with `@pytest.mark.integration`. Body per Test 2 behavior.
+    - For the cluster-name string in Test 2, use the `kind_cluster` fixture yield (the string `"test-pipe-integration"` from `tests/integration/conftest.py`).
+    - For Test 2, use the helper `_decode_token_payload` defined inline (same logic as Plan 02-01's unit test — duplicate the 5-line helper here since the integration tier should not import from `tests/unit/`).
+    - Both tests use the fixture credentials `"AKIAIOSFODNN7EXAMPLE"` / `"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"` per RESEARCH Section G — these are the documented AWS-dev test keys, NOT real credentials.
+
+    Run verification on a developer machine with kind installed: `uv run pytest -m integration -q --no-cov tests/integration/test_auth_smoke.py`. Expected: both tests pass when kind is present; both skip cleanly when kind is absent (since Test 2's `kind_cluster` fixture is session-scoped and skips before either test runs).
+
+    NOTE: Test 1 does NOT actually require kind — but because `kind_cluster` is session-scoped and `pytest.skip` is called from the fixture, when kind is missing, the fixture's skip propagates to the WHOLE session via collection-time signaling? Actually no — fixtures only skip the tests that REQUEST them. Test 1 does NOT request `kind_cluster`, so Test 1 runs even without kind. This is correct behavior.
+
+    Stub call-out: the integration tier is intentionally lightweight in Phase 2. Phase 3 adds a real `UpgradeAction` integration test that ACTUALLY deploys a chart to the kind cluster. Phase 2's integration tests prove the wiring shape only.
+  </action>
+  <verify>
+    <automated>uv run pytest -m integration -q --no-cov tests/integration/test_auth_smoke.py</automated>
+  </verify>
+  <done>
+    Two integration tests exist; both `@pytest.mark.integration`; Test 1 always runs (no kind needed); Test 2 skips cleanly when kind is missing; both pass on a host with kind installed; the kind cluster is created+torn down by the existing Phase 1 fixture (no fixture changes here).
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| `Settings` (consumer env vars) → `select_strategy` decision tree | The decision is purely structural — presence/absence of typed fields. Settings already validated by pydantic. |
+| `select_strategy` → `StaticKeysStrategy` / `AssumeRoleStrategy` constructor | Credential VALUES pass through. We never log them. The `bind_safe_context` contract ensures they cannot leak to structlog. |
+| `os.environ.get("BITBUCKET_PIPELINE_UUID")` / `BITBUCKET_BUILD_NUMBER` | Bitbucket-platform-supplied; trusted as identifiers (not credentials). Used ONLY for session-name derivation. |
+| `cli.main()` → `pipe.fail(exc.user_message)` on ConfigurationError | The error message text is hardcoded by `select_strategy` — does NOT contain credential values (the message templates are static strings). |
+| Integration test — `boto3.Session(aws_access_key_id="AKIAIOSFODNN7EXAMPLE", ...)` | Documented AWS-dev test keys — NOT real credentials. Cannot be used for any real AWS API call. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-04-01 | Information Disclosure | `bind_safe_context(auth_strategy=type(strategy).__name__)` | mitigate | The class name (`"StaticKeysStrategy"`, `"AssumeRoleStrategy"`) is NOT a credential. The Phase 1 `CREDENTIAL_BLOCKLIST` does not include `auth_strategy` (it IS in `STABLE_FIELDS` — public log key). |
+| T-02-04-02 | Information Disclosure | `_derive_session_name` reading `os.environ` | mitigate | The two env vars (`BITBUCKET_PIPELINE_UUID`, `BITBUCKET_BUILD_NUMBER`) are platform identifiers, not credentials. The derived session name appears in IAM session logs (CloudTrail) — this is intentional traceability. |
+| T-02-04-03 | Elevation of Privilege | Consumer-supplied `SESSION_NAME` bypasses derivation | mitigate | `_derive_session_name` enforces the 64-char limit AND validates against the IAM character class. Invalid values fall through to UUID generation. |
+| T-02-04-04 | Spoofing | `auth_strategy=type(strategy).__name__` lies about the actual strategy when monkeypatched in tests | accept | This is a test-only concern; in production, the strategy class name accurately reflects the runtime selection. |
+| T-02-04-05 | Information Disclosure | `ConfigurationError("ROLE_ARN requires ...")` message includes the literal `"ROLE_ARN"` token | accept | This is intentional UX — consumers debugging a misconfiguration need to know which env var to set. No credential VALUE is in the message. |
+| T-02-04-SC | Tampering | Package legitimacy — same packages as prior plans | mitigate | No new packages introduced. |
+</threat_model>
+
+<deviations>
+## Documented Deviations from ROADMAP / RESEARCH
+
+### Deviation 1: `_derive_session_name` reads `os.environ` directly
+
+**Decision:** `_derive_session_name` calls `os.environ.get("BITBUCKET_PIPELINE_UUID")` and `os.environ.get("BITBUCKET_BUILD_NUMBER")` directly, bypassing the Phase 1 PATTERNS.md "no `os.environ` outside `settings.py`" rule.
+
+**Rationale:** These two env vars are Bitbucket-platform-supplied, not consumer-supplied via `pipe.yml`. Adding them to `Settings` would imply they are tunable by the pipe consumer — they are not. Reading them as a side-channel ONLY for session-name derivation keeps `Settings` clean.
+
+**Action item:** If Phase 4 (OIDC) needs MORE Bitbucket-platform env vars (e.g., `BITBUCKET_STEP_OIDC_TOKEN`), reconsider promoting them into a `BitbucketPlatformSettings` sub-model for testability. For Phase 2, the one-shot lookup is the right pragmatic choice.
+
+### Deviation 2: Phase 1 OBS-01 PARTIAL gap is closed by Task 02-4-02
+
+**Decision:** Adding `logger.info("auth strategy selected", auth_strategy=type(strategy).__name__)` to `cli.py` closes the Phase 1 verification PARTIAL note — `LOG_FORMAT=json docker run ...` now emits at least one parseable JSON line on stderr.
+
+**Rationale (per Phase 1 VERIFICATION.md):** the Phase 1 verifier explicitly flagged SC5 as PARTIAL because `cli.py` had NO `structlog` emission at runtime. Phase 1's PLAN-04 documented this as deferred to "Phase 2+ action dispatch". Phase 2 IS that phase — closing the gap here is on-roadmap, not scope creep.
+
+**Action item:** Phase 1's `01-VERIFICATION.md` PARTIAL note may be retroactively resolved when Phase 2 ships. The verifier for Phase 2 can confirm by running the documented `LOG_FORMAT=json docker run ...` smoke from Phase 1 VALIDATION.md "Manual-Only" table.
+
+### Deviation 3: `cli.main()` does NOT call `strategy.get_credentials()` in Phase 2
+
+**Decision:** Phase 2 selects the strategy but never invokes it. Calling `.get_credentials()` would trigger STS API calls (for `AssumeRoleStrategy`) every time the pipe runs — that's wrong for the placeholder path. Phase 3 (`UpgradeAction`) is where credentials are actually fetched, the boto3 Session is built, and `generate_eks_token` is called.
+
+**Rationale:** Strict scope discipline — Phase 2 ships AUTH wiring; Phase 3 ships ACTION dispatch. The placeholder success message ("Phase 2 skeleton — auth strategy selected") makes the discipline visible.
+
+**Action item:** None. Phase 3 implementation lands the actual `.get_credentials()` call inside `UpgradeAction.run()`.
+</deviations>
+
+<dependencies_on_prior_plans>
+## Prior Plan Inputs
+
+- **Plan 02-01 (THIS PHASE, wave 1):** `generate_eks_token` from `aws/eks_token.py` — consumed by the integration test (Task 02-4-03). STRICT dependency.
+- **Plan 02-02 (THIS PHASE, wave 1):** `AuthStrategy` Protocol + `AwsCredentials` — re-exported from `auth/__init__.py`. STRICT.
+- **Plan 02-03 (THIS PHASE, wave 2):** `StaticKeysStrategy`, `AssumeRoleStrategy` — instantiated by `select_strategy`. STRICT.
+- **Phase 1:**
+  - `src/aws_eks_helm_deploy/settings.py` — `Settings` fields; THIS plan adds `aws_session_token` field if not already present (per Plan 02-03 read note).
+  - `src/aws_eks_helm_deploy/logging.py` — `bind_safe_context`, `get_logger`, `STABLE_FIELDS` (includes `auth_strategy`), `CREDENTIAL_BLOCKLIST`.
+  - `src/aws_eks_helm_deploy/cli.py` — Phase 1 placeholder; THIS plan extends it.
+  - `tests/integration/conftest.py::kind_cluster` — session-scoped fixture; reused by Task 02-4-03's Test 2.
+</dependencies_on_prior_plans>
+
+<dependencies_on_other_phases>
+## Forward Compatibility
+
+- **Phase 3 (`UpgradeAction`):** `actions/upgrade.py` will call `strategy.get_credentials()`, build `boto3.Session(region_name=settings.aws_region, **creds.to_boto3_kwargs())`, call `generate_eks_token(session, settings.cluster_name, settings.aws_region)`, and inline the token into the kubeconfig built by `kube/kubeconfig.py`. The `cli.main()` action dispatch table will call `UpgradeAction(strategy, settings).run()` once `settings.action == "upgrade"` is implemented.
+- **Phase 4 (`auth/oidc.py::OidcWebIdentityStrategy`):** Replaces the `# Phase 4: insert OIDC check here` comment in `select_strategy` with:
+  ```python
+  if settings.oidc_audience and settings.role_arn:
+      return OidcWebIdentityStrategy(...)
+  ```
+  Phase 2's decision-tree shape is forward-compatible with this insertion.
+- **Phase 5 (`SEC-06` log masking):** does NOT touch `cli.py` auth wiring — log redaction is layered on top of helm output, not strategy selection.
+
+## Stable contracts (do NOT refactor without bumping major)
+
+```
+def select_strategy(settings: Settings) -> AuthStrategy: ...
+def _derive_session_name(settings: Settings) -> str: ...  # internal helper
+
+# cli.main() invariant: select_strategy(settings) is called between configure_logging and PipeIO construction
+```
+</dependencies_on_other_phases>
+
+<known_stubs>
+## Known Stubs / Scaffolds
+
+- **`# Phase 4: insert OIDC check here` comment** in `select_strategy` — a forward-marker, NOT a code stub. Phase 4 of the roadmap replaces it.
+- **`cli.main()` placeholder success path** — Phase 1 stub continues. Phase 3 replaces it with real action dispatch.
+- **`PipeIO` stub** — Phase 1 stub continues. Phase 3 may add schema-driven init if `pipe.yml` schema is finalized.
+- **`_derive_session_name` graceful degradation on invalid SESSION_NAME** — falls through to UUID. If consumers complain that their custom session names are silently replaced, Phase 2.1 could elevate this to a `ConfigurationError`. Not a stub — an intentional design choice with a re-evaluation hook.
+</known_stubs>
+
+<verification>
+- `uv run ruff check src tests` exits 0.
+- `uv run ruff format --check src tests` exits 0.
+- `uv run mypy --strict src` exits 0.
+- `uv run pytest -q` (full unit tier with 100% gate) exits 0 — no regression on any prior plan.
+- `uv run pytest -m unit -q tests/unit/test_auth_select.py --cov=aws_eks_helm_deploy.auth --cov-branch --cov-fail-under=100 --no-header` exits 0.
+- `uv run pytest -m unit -q tests/unit/test_cli.py --cov=aws_eks_helm_deploy.cli --cov-branch --cov-fail-under=100 --no-header` exits 0.
+- `uv run pytest -m integration -q --no-cov tests/integration/test_auth_smoke.py` exits 0 (when kind is installed) OR skips cleanly (when kind is absent).
+- `LOG_FORMAT=json AWS_ACCESS_KEY_ID=AKIA-FAKE AWS_SECRET_ACCESS_KEY=fake-secret python -m aws_eks_helm_deploy 2>&1 1>/dev/null | python -c "import sys, json; [json.loads(l) for l in sys.stdin if l.strip()]"` exits 0 (closes Phase 1 OBS-01 PARTIAL gap).
+- `python -c "from aws_eks_helm_deploy.auth import select_strategy, AuthStrategy, AwsCredentials; print('OK')"` exits 0.
+</verification>
+
+<success_criteria>
+- AUTH-01 (full): `select_strategy(settings)` composes the typed Protocol with concrete strategies; `auth/__init__.py` is the public composition root.
+- AUTH-02 (full): `AssumeRoleStrategy` is composable on top of any base — verified by the decision-tree tests.
+- AUTH-07 (end-to-end wire): the integration test proves `Settings → select_strategy → AwsCredentials → boto3.Session → generate_eks_token` produces a structurally valid token.
+- 100% line+branch coverage on `auth/__init__.py` AND `cli.py` (new branches).
+- Phase 1 OBS-01 PARTIAL gap is CLOSED: at least one structlog JSON line emitted on stderr at runtime.
+- `cli.main()` propagates `ConfigurationError` from `select_strategy` via the existing PipeError handler (exit code 1).
+- Credentials are NEVER passed to `bind_safe_context` (Plan 02-02 contract holds).
+- Stubs explicitly named: cli placeholder success message, Phase 4 OIDC marker, PipeIO stub.
+</success_criteria>
+
+<artifacts>
+## Artifacts this plan produces (Plan 02-04 scope)
+
+**Files (new):**
+- `tests/unit/test_auth_select.py` — 14+ unit tests covering all four decision branches + `_derive_session_name` paths.
+- `tests/integration/test_auth_smoke.py` — 2 integration tests (StaticKeys shape + EKS token shape).
+
+**Files (modified):**
+- `src/aws_eks_helm_deploy/auth/__init__.py` — REPLACES the empty Plan 02-02 placeholder with `select_strategy` + `_derive_session_name` + public re-exports.
+- `src/aws_eks_helm_deploy/cli.py` — adds `select_strategy` call, `bind_safe_context`, `logger.info` emission. Existing structure preserved.
+- `src/aws_eks_helm_deploy/settings.py` — conditionally adds `aws_session_token: str | None = Field(default=None, alias="AWS_SESSION_TOKEN")` if not already present (the planner expects it already there per file pre-read, but the executor verifies and adds if missing).
+- `tests/unit/test_cli.py` — extends existing file with 5 new tests + `_fake_strategy` fixture; existing 4 tests use the fixture to short-circuit auth.
+
+**New Python symbols (importable):**
+- `aws_eks_helm_deploy.auth.select_strategy(settings: Settings) -> AuthStrategy`.
+- `aws_eks_helm_deploy.auth.AuthStrategy`, `AwsCredentials`, `StaticKeysStrategy`, `AssumeRoleStrategy` — re-exports.
+- Module-private: `_derive_session_name(settings: Settings) -> str`.
+
+**Stubs (explicitly called out):**
+- `# Phase 4: insert OIDC check here` — comment marker for Phase 4 of the roadmap.
+- `cli.main()` placeholder success — Phase 3 replaces with action dispatch.
+- `PipeIO` Phase 1 stub continues unchanged.
+- `_derive_session_name` invalid-SESSION_NAME graceful degradation — Phase 2.1 re-evaluation hook (NOT a code TODO).
+</artifacts>
+
+<output>
+On completion, create `.planning/phases/02-aws-layer-auth-foundation/02-04-SUMMARY.md` recording:
+- Final coverage % on `auth/__init__.py` AND `cli.py` (must be 100%).
+- Confirmation that the Phase 1 OBS-01 PARTIAL gap is CLOSED (`LOG_FORMAT=json python -m aws_eks_helm_deploy 2>&1` emits a parseable JSON line).
+- Confirmation that `aws_session_token` field is present on `Settings` (either already there from Phase 1 or added by this plan; report which).
+- Confirmation that all four decision-tree branches in `select_strategy` are covered by tests.
+- The integration smoke test outcome on the developer's machine (passed / skipped due to no kind).
+- Re-statement of the three deviations (os.environ for BB envars; OBS-01 PARTIAL gap closure; no get_credentials() invocation in Phase 2).
+- The full Phase 2 file-modification roll-up so the orchestrator can confirm AUTH-01 + AUTH-02 + AUTH-07 satisfied across the four plans.
+</output>

--- a/.planning/phases/02-aws-layer-auth-foundation/02-PLAN-CHECK.md
+++ b/.planning/phases/02-aws-layer-auth-foundation/02-PLAN-CHECK.md
@@ -1,0 +1,90 @@
+# Phase 2 Plan-Check Report
+
+**Verdict:** `APPROVED-WITH-WARNINGS`
+**Blockers:** 0
+**Warnings:** 3 (all non-blocking)
+**Reviewer:** gsd-plan-checker (Sonnet)
+**Date:** 2026-06-17
+
+## Goal-Backward Verdict
+
+After all four plans execute, the Phase 2 goal is substantively achieved:
+- `AuthStrategy` Protocol + `AwsCredentials` ship (02-02)
+- `StaticKeysStrategy` + `AssumeRoleStrategy` ship (02-03)
+- `select_strategy(settings)` composes them (02-04)
+- `generate_eks_token` via pure boto3 ships (02-01)
+- `cli.py` is wired to call `select_strategy` before any action
+- `structlog` emits `auth_strategy` to close the Phase 1 OBS-01 PARTIAL gap
+- `aws_session_token` is added to `Settings` (research caught its absence)
+
+AUTH-01, AUTH-02, AUTH-07 fully delivered. No Phase 3 scope creep.
+
+## Per-Success-Criterion Coverage
+
+| SC | Description | Status |
+|----|-------------|--------|
+| SC1 | `auth/base.py` Protocol + `AwsCredentials`; independent strategies; `select_strategy` composes | PASS |
+| SC2 | `aws/eks_token.py` pure-boto3 token; golden test (deviation documented) | PASS (with documented deviation: structural-equivalence instead of byte-equal — impossible per RESEARCH §A) |
+| SC3 | `pyproject.toml` declares `boto3`, no `awscli`; `docker history` shows no awscli layer | WARNING — manual gate only, no automated CI test |
+| SC4 | 100% coverage; kind-backed integration test produces kubeconfig helm accepts | WARNING — integration test verifies token shape only; kubeconfig writer lands Phase 3 |
+
+## Per-REQ Coverage
+
+| REQ | Plans | Tasks | Status |
+|-----|-------|-------|--------|
+| AUTH-01 | 02-02, 02-03, 02-04 | 02-2-01, 02-3-01, 02-4-01 | PASS |
+| AUTH-02 | 02-03, 02-04 | 02-3-02, 02-4-01 | PASS |
+| AUTH-07 | 02-01 | 02-1-01, 02-1-02 | PASS |
+
+## Wave / Dependency Correctness
+
+- 02-01 wave 1 (no deps) — eks_token.py independent foundation
+- 02-02 wave 1 (no deps) — Protocol + dataclass
+- 02-03 wave 2 (depends 02-02) — concrete strategies
+- 02-04 wave 3 (depends 02-01, 02-02, 02-03) — composition root + cli + integration test
+
+No same-wave file overlap. `auth/__init__.py` created empty by 02-02, replaced by 02-04 — wave ordering prevents conflict.
+
+## Threat-Model Completeness
+
+All four plans carry STRIDE tables. Credentials non-disclosure verified: `bind_safe_context` integration tested in 02-02 + 02-04; `CREDENTIAL_BLOCKLIST` covers `aws_*_key/token`, `role_arn`. `__repr__` masking specified for `AwsCredentials`. ClientError messages use only `Code` + `Message` (no ARN/credential exposure).
+
+## 100% Coverage Feasibility
+
+All four plans designed for `--cov-fail-under=100`: explicit error-branch tests, moto-backed happy paths, parametrized tests on CREDENTIAL_BLOCKLIST. Phase 1's gate inherits cleanly.
+
+## Warnings (non-blocking)
+
+### Warning 1 — SC3 lacks automated acceptance gate
+
+`docker history` / awscli-not-importable check is only in VALIDATION.md as a **manual** gate. No `tests/acceptance/` extension. Risk is low (Phase 1 already confirmed clean Dockerfile) but the ROADMAP wording is not fully automated.
+
+**Fix hint (deferred to execution):** Plan 02-04 Task 02-4-02 could add `test_awscli_not_importable` to `tests/acceptance/test_image_smoke.py`:
+```python
+def test_awscli_not_importable(built_image: str) -> None:
+    result = subprocess.run(
+        ["docker", "run", "--rm", built_image, "python", "-c", "import awscli"],
+        capture_output=True, text=True
+    )
+    assert result.returncode != 0
+    assert "No module named" in result.stderr
+```
+
+### Warning 2 — SC4 kubeconfig-helm integration deferred to Phase 3
+
+The ROADMAP says "produce a kubeconfig that helm accepts". The Phase 2 integration test verifies token shape only — the kubeconfig writer (`kube/kubeconfig.py`) ships in Phase 3. This is intentional and correct scope-wise, but worth surfacing in 02-VALIDATION.md.
+
+**Fix hint (apply during execution):** Append to 02-VALIDATION.md ROADMAP/RESEARCH Deviation Surface:
+> 4. **ROADMAP Phase 2 SC4 "kubeconfig that helm accepts"** — the Phase 2 integration test verifies EKS token SHAPE only (structural properties). The kubeconfig writer (`kube/kubeconfig.py`) ships in Phase 3; end-to-end helm acceptance of the kubeconfig is a Phase 3 integration test responsibility.
+
+### Warning 3 — assume-role test mocking pattern clarification
+
+Task 02-3-02 documents two viable test patterns (patch `Session.client` vs `@mock_aws` + spy). The executor must pick the right one per assertion type. Plan documents both; explicit per-test pattern assignment would reduce executor implementation risk.
+
+**Fix hint (executor judgment call):** No plan edit needed; executor will choose based on the planner's documented patterns.
+
+## Conclusion
+
+Plans are executor-ready. Warnings 1 and 2 are recommended fixes during execution (small additions to acceptance test + validation doc). Warning 3 is an executor judgment call. No replanning needed.
+
+`STATUS=APPROVED-WITH-WARNINGS WARNINGS=3 BLOCKERS=0`

--- a/.planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md
+++ b/.planning/phases/02-aws-layer-auth-foundation/02-RESEARCH.md
@@ -1,0 +1,814 @@
+# Phase 2 Research: AWS Layer & Auth Foundation
+
+**Researched:** 2026-06-17
+**Domain:** AWS authentication with boto3, EKS presigned-URL token generation, AuthStrategy Protocol design
+**Confidence:** HIGH — all code patterns verified by running against the installed venv (boto3 1.43.31, moto 5.2.2, Python 3.13); all package versions confirmed from PyPI; awscli token generation algorithm confirmed against upstream source
+
+---
+
+## Scope Summary
+
+Phase 2 wires AWS credential acquisition and EKS token generation into the skeleton that Phase 1 built.
+Three requirements ship: AUTH-01 (typed `AuthStrategy` Protocol + `StaticKeysStrategy`), AUTH-02
+(`AssumeRoleStrategy` composed on top of any base strategy), and AUTH-07 (pure-boto3 EKS token, no
+awscli). The phase produces five new Python modules, zero changes to `Dockerfile` or `pyproject.toml`
+(both are already clean — `awscli` was never added, `boto3 ~= 1.43` and `moto[eks,sts] ~= 5.2` are
+already declared), and extends `cli.py` with the auth wire-in placeholder.
+
+---
+
+## A. EKS Token Format and Generation
+
+### Wire Format
+
+The EKS bearer token passed in a kubeconfig `exec` credential or directly in the `token:` field is:
+
+```
+k8s-aws-v1.<base64url-no-padding(presigned-STS-GetCallerIdentity-URL)>
+```
+
+Constants (from awscli source `awscli/customizations/eks/get_token.py` and aws-iam-authenticator
+`pkg/token/token.go`):
+
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `TOKEN_PREFIX` | `"k8s-aws-v1."` | Literal prefix, not base64 |
+| `K8S_AWS_ID_HEADER` | `"x-k8s-aws-id"` | Must be signed into the presigned URL |
+| `URL_TIMEOUT` | `60` | `X-Amz-Expires=60` in the URL; hardcoded for backward compat |
+| Token validity | 15 minutes | Determined by the X-Amz-Date + cluster-side validation logic |
+
+`[CITED: https://github.com/aws/aws-cli/blob/develop/awscli/customizations/eks/get_token.py]`
+
+### How the kube-apiserver Validates the Token
+
+The EKS control plane runs an authentication webhook. When `kubectl` (or helm) presents this bearer
+token, the webhook:
+1. Strips the `k8s-aws-v1.` prefix
+2. Base64url-decodes (adding back the stripped `=` padding as needed) to get the presigned URL
+3. Makes an HTTP GET to that URL (calling STS `GetCallerIdentity`)
+4. Verifies the response contains `x-k8s-aws-id` header matching the cluster name
+5. Maps the returned ARN to a Kubernetes principal via the aws-auth ConfigMap or access entries
+
+The presigned URL **must** target a regional STS endpoint (`sts.{region}.amazonaws.com`), not the
+global endpoint (`sts.amazonaws.com`). Clusters set their preferred STS endpoint at creation time;
+most regions require the regional endpoint. `[CITED: https://github.com/kubernetes-sigs/aws-iam-authenticator]`
+
+### Required URL Parameters
+
+The presigned URL must have these characteristics (verified by running the full generation against
+a boto3 client in the project venv):
+
+- `X-Amz-Algorithm=AWS4-HMAC-SHA256`
+- `X-Amz-Expires=60`
+- `X-Amz-SignedHeaders=host;x-k8s-aws-id` — the cluster ID header is **signed** into the URL
+- `Action=GetCallerIdentity`
+- `HttpMethod=GET` (not POST — GET presigned URL so no body is sent)
+
+The `x-k8s-aws-id` header is **not** passed in the Params dict of `generate_presigned_url` directly
+(that would fail validation). It is injected via botocore's event system before signing, so it
+becomes part of `SignedHeaders`. `[VERIFIED: tested in project venv]`
+
+### Pure-boto3 Implementation Pattern
+
+The awscli uses botocore's event emitter to inject the custom header before the request is signed.
+The identical mechanism works with boto3's `client.meta.events`. This is the canonical pattern and
+has been verified to produce a conforming token:
+
+```python
+# src/aws_eks_helm_deploy/aws/eks_token.py
+from __future__ import annotations
+
+import base64
+
+import boto3
+import boto3.session
+
+TOKEN_PREFIX = "k8s-aws-v1."
+K8S_AWS_ID_HEADER = "x-k8s-aws-id"
+URL_TIMEOUT = 60  # seconds; hardcoded per upstream spec
+
+
+def generate_eks_token(session: boto3.session.Session, cluster_name: str, region: str) -> str:
+    """Generate a k8s-aws-v1.<base64url> bearer token for EKS via pure boto3.
+
+    Replicates the algorithm from awscli.customizations.eks.get_token without
+    importing awscli. The x-k8s-aws-id header is injected into the presigned
+    URL via botocore events so it appears in X-Amz-SignedHeaders.
+
+    Args:
+        session: A boto3.Session pre-configured with the desired credentials.
+        cluster_name: EKS cluster name (becomes the x-k8s-aws-id header value).
+        region: AWS region where the cluster lives (determines STS endpoint).
+
+    Returns:
+        Bearer token string starting with 'k8s-aws-v1.'.
+    """
+    sts = session.client(
+        "sts",
+        endpoint_url=f"https://sts.{region}.amazonaws.com",
+    )
+
+    # Storage for the header value across event calls
+    _header_store: dict[str, str] = {}
+
+    def _retrieve_header(params: dict, **kwargs: object) -> None:  # noqa: ANN003
+        if K8S_AWS_ID_HEADER in params:
+            _header_store["value"] = params.pop(K8S_AWS_ID_HEADER)
+
+    def _inject_header(request: object, **kwargs: object) -> None:  # noqa: ANN001 ANN003
+        if "value" in _header_store:
+            request.headers[K8S_AWS_ID_HEADER] = _header_store["value"]  # type: ignore[union-attr]
+
+    sts.meta.events.register(
+        "provide-client-params.sts.GetCallerIdentity", _retrieve_header
+    )
+    sts.meta.events.register(
+        "before-sign.sts.GetCallerIdentity", _inject_header
+    )
+
+    url: str = sts.generate_presigned_url(
+        "get_caller_identity",
+        Params={K8S_AWS_ID_HEADER: cluster_name},
+        ExpiresIn=URL_TIMEOUT,
+        HttpMethod="GET",
+    )
+    token = TOKEN_PREFIX + base64.urlsafe_b64encode(
+        url.encode("utf-8")
+    ).decode("utf-8").rstrip("=")
+    return token
+```
+
+`[VERIFIED: tested in project venv — token starts with k8s-aws-v1., decoded URL contains x-k8s-aws-id in X-Amz-SignedHeaders, X-Amz-Expires=60]`
+
+### Golden Test Strategy
+
+The golden test approach compares the **structural properties** of the generated token, not a
+byte-for-byte comparison against `aws eks get-token` output. A byte-for-byte comparison is
+impossible in practice because the presigned URL includes `X-Amz-Date` (changes per invocation)
+and the HMAC signature (changes with credentials and timestamp). What is stable and testable:
+
+1. Token starts with `k8s-aws-v1.`
+2. Stripping prefix + adding back `=` padding + base64url-decode yields a valid URL
+3. Decoded URL contains `X-Amz-Expires=60`
+4. Decoded URL contains `x-k8s-aws-id` in `X-Amz-SignedHeaders`
+5. Decoded URL `Action` query param is `GetCallerIdentity`
+6. Decoded URL hostname is `sts.{region}.amazonaws.com` (regional, not global)
+7. Token contains no `=` padding characters
+
+Under `@mock_aws`, moto generates valid presigned URLs (verified in project venv). Cluster-name
+injection works identically in unit tests — use `@mock_aws` for all EKS token unit tests.
+
+**Note on ROADMAP.md claim:** The ROADMAP states "golden unit test asserts byte-equal to `aws eks get-token` reference output". This is architecturally impossible (timestamp + HMAC changes per call). Interpret this as "structurally equivalent" — assert the properties above rather than byte equality. `[ASSUMED]` that the intent is structural equivalence; if true byte-equality was required, the test would always be flaky.
+
+### Common Pitfalls
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Using global STS endpoint (`sts.amazonaws.com`) | Token rejected by cluster's STS authenticator | Always construct with `endpoint_url=f"https://sts.{region}.amazonaws.com"` |
+| Missing `x-k8s-aws-id` header injection | URL missing header in `X-Amz-SignedHeaders` → token rejected | Register both botocore events before calling `generate_presigned_url` |
+| Passing `x-k8s-aws-id` in `Params` dict without event registration | `ParamValidationError: Unknown parameter in input: "x-k8s-aws-id"` | Register `provide-client-params.sts.GetCallerIdentity` event first to extract the header |
+| Using `HttpMethod='POST'` | STS returns 400 (presigned GET has no body) | Always use `HttpMethod='GET'` |
+| Including `=` padding in the token | Token rejected by kube-apiserver | `.rstrip('=')` after base64url encoding |
+| Wrong base64 encoding (standard, not urlsafe) | Token contains `+` or `/` which are invalid in URL path components | Use `base64.urlsafe_b64encode` |
+
+### References
+
+- awscli source: `https://github.com/aws/aws-cli/blob/develop/awscli/customizations/eks/get_token.py`
+  — authoritative Python implementation; `STSClientFactory`, `TokenGenerator`, all constants
+- aws-iam-authenticator: `https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/pkg/token/token.go`
+  — Go reference implementation; `v1Prefix`, `clusterIDHeader`, `requestPresignParam` constants
+- Boto3 `generate_presigned_url` signature (verified in venv): `(ClientMethod, Params=None, ExpiresIn=3600, HttpMethod=None)`
+
+---
+
+## B. AuthStrategy Protocol Design
+
+### Protocol Definition
+
+Use `typing.Protocol` with `@runtime_checkable`. The `@runtime_checkable` decorator enables
+`isinstance(obj, AuthStrategy)` checks in `select_strategy` and in tests. Structural subtyping
+(duck typing) means no inheritance is required — `StaticKeysStrategy`, `AssumeRoleStrategy`, and
+the future `OidcWebIdentityStrategy` (Phase 4) all satisfy the Protocol by having the right method
+signature. `[VERIFIED: tested in project venv]`
+
+```python
+# src/aws_eks_helm_deploy/auth/base.py
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class AuthStrategy(Protocol):
+    """Protocol satisfied by any credential provider."""
+
+    def get_credentials(self) -> AwsCredentials:
+        """Return a set of AWS credentials. Must not cache or refresh internally."""
+        ...
+```
+
+**Why not `@abstractmethod` / ABC?** ABCs require inheritance, breaking the structural typing
+model. Phase 4's `OidcWebIdentityStrategy` lives in a separate module and should not inherit from
+a base class in `auth/base.py` — that would create a coupling that the Protocol design avoids.
+
+### AwsCredentials Value Object
+
+```python
+# In src/aws_eks_helm_deploy/auth/base.py (same file as Protocol)
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime
+
+
+@dataclasses.dataclass(frozen=True)
+class AwsCredentials:
+    """Immutable AWS credential set.
+
+    The __repr__ masks sensitive fields — safe to pass to get_logger().
+    Never log or bind the actual secret values.
+    """
+
+    access_key_id: str
+    secret_access_key: str
+    session_token: str | None = None
+    expiration: datetime | None = None
+
+    def __repr__(self) -> str:
+        tail = self.access_key_id[-4:] if len(self.access_key_id) >= 4 else "****"
+        return f"AwsCredentials(access_key_id=...{tail}, secret_access_key=<redacted>)"
+
+    def to_boto3_kwargs(self) -> dict[str, str]:
+        """Return a dict suitable for spreading into boto3.Session() or client()."""
+        kwargs: dict[str, str] = {
+            "aws_access_key_id": self.access_key_id,
+            "aws_secret_access_key": self.secret_access_key,
+        }
+        if self.session_token is not None:
+            kwargs["aws_session_token"] = self.session_token
+        return kwargs
+```
+
+**Why `dataclass(frozen=True)` not Pydantic?** `AwsCredentials` is an internal value object, not a
+settings model. Pydantic adds a 40-60 ms cold-import overhead and brings validator complexity that
+is not needed here. A frozen dataclass provides immutability, structural equality (`__eq__`,
+`__hash__`), and controlled `__repr__` with zero extra dependencies. `[ASSUMED: performance
+estimate from general knowledge; the immutability argument is verifiable]`
+
+**Why not `NamedTuple`?** `NamedTuple` does not support `frozen=True`-style immutability on
+assignment (only structural); mypy-strict handles both equally. The `dataclass` offers a clean path
+to adding `__post_init__` validation (e.g., non-empty key assertion) if needed later.
+
+**Integration with `CREDENTIAL_BLOCKLIST`:** `AwsCredentials.__repr__` never exposes raw secrets.
+The keys `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` are already in the
+`CREDENTIAL_BLOCKLIST` in `logging.py`. Calling `bind_safe_context(creds=repr(creds))` is safe;
+calling `bind_safe_context(**creds.to_boto3_kwargs())` will raise `ValueError` — this is the
+intended behavior. Pass only the string name of the strategy to structlog context, never the
+credentials object itself.
+
+---
+
+## C. boto3 / botocore Patterns
+
+### Session Construction
+
+Always construct a `boto3.Session` from explicit credentials — never rely on environment variable
+fall-through for strategy-controlled credential sets. The `to_boto3_kwargs()` method on
+`AwsCredentials` produces exactly the right dict:
+
+```python
+import boto3
+import botocore.config
+
+session = boto3.Session(
+    region_name=settings.aws_region,
+    **credentials.to_boto3_kwargs(),  # access_key_id, secret_access_key, optional session_token
+)
+```
+
+For the STS client used in `AssumeRoleStrategy`, pass `endpoint_url` explicitly to force the
+regional endpoint:
+
+```python
+sts = session.client(
+    "sts",
+    endpoint_url=f"https://sts.{region}.amazonaws.com",
+    config=botocore.config.Config(
+        retries={"max_attempts": 3, "mode": "standard"},
+    ),
+)
+```
+
+### Regional STS Endpoints
+
+The `AWS_STS_REGIONAL_ENDPOINTS=regional` environment variable is the awscli mechanism; it is not
+honoured by boto3 without a `botocore.config.Config` change. The cleanest boto3-native approach is
+the explicit `endpoint_url` shown above. Do not rely on the environment variable. `[VERIFIED: tested
+with explicit endpoint_url in project venv — URL in generated presigned URL contains region]`
+
+### Retry Policy
+
+The default botocore retry configuration (3 attempts, exponential backoff, "legacy" mode) is
+acceptable for Phase 2 — this is a CI pipe that runs once per build. Prefer `mode="standard"` over
+`mode="legacy"` for new code (standard mode includes additional retry-able status codes). No custom
+retry logic is needed.
+
+### Error Handling
+
+Wrap all boto3/botocore API calls in a `try/except botocore.exceptions.ClientError` and convert to
+the project's typed error hierarchy:
+
+```python
+import botocore.exceptions
+
+from aws_eks_helm_deploy.errors import AuthenticationError, ConfigurationError
+
+try:
+    response = sts.assume_role(RoleArn=role_arn, RoleSessionName=session_name)
+except botocore.exceptions.ClientError as exc:
+    code = exc.response["Error"]["Code"]
+    raise AuthenticationError(
+        f"STS AssumeRole failed [{code}]: {exc.response['Error']['Message']}"
+    ) from exc
+except botocore.exceptions.NoCredentialsError as exc:
+    raise ConfigurationError("No AWS credentials found") from exc
+```
+
+`AuthenticationError` maps to exit code 2 (already defined in `errors.py`). Do not let
+`botocore.exceptions.ClientError` propagate uncaught — it would fall through to the `except
+Exception` handler in `cli.main()` and return exit code 99, losing the typed exit code.
+
+### AssumeRole Response TypedDict
+
+`mypy-boto3-sts` (already in `boto3-stubs[eks,sts]` dev dependency, version 1.43.0 installed)
+provides `CredentialsTypeDef` with fields `AccessKeyId`, `SecretAccessKey`, `SessionToken`,
+`Expiration`. Use it for type annotation:
+
+```python
+from mypy_boto3_sts.type_defs import CredentialsTypeDef
+
+creds: CredentialsTypeDef = response["Credentials"]
+return AwsCredentials(
+    access_key_id=creds["AccessKeyId"],
+    secret_access_key=creds["SecretAccessKey"],
+    session_token=creds["SessionToken"],
+    expiration=creds["Expiration"],
+)
+```
+
+`[VERIFIED: mypy_boto3_sts.type_defs.CredentialsTypeDef with fields AccessKeyId, SecretAccessKey, SessionToken, Expiration confirmed in project venv]`
+
+---
+
+## D. AwsCredentials Value Object (complete spec)
+
+Full field specification for the planner:
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `access_key_id` | `str` | required | IAM access key ID (starts `AKIA` for long-term, `ASIA` for temporary) |
+| `secret_access_key` | `str` | required | Never log; `__repr__` shows `<redacted>` |
+| `session_token` | `str \| None` | `None` | Required for assumed-role and session-token credentials |
+| `expiration` | `datetime \| None` | `None` | UTC datetime from STS; `None` for long-term keys |
+
+`to_boto3_kwargs()` produces `{"aws_access_key_id": ..., "aws_secret_access_key": ...,
+"aws_session_token": ...}` (session_token included only if not `None`). Return type is
+`dict[str, str]` — all values are strings, including `session_token` (the expiration datetime is
+not passed to boto3).
+
+**No caching required:** A Bitbucket Pipe runs once and exits. There is no long-running process
+that would benefit from credential refresh. `AssumeRoleStrategy.get_credentials()` calls STS on
+every invocation — this is correct behavior.
+
+---
+
+## E. ROLE_ARN Composability (AUTH-02)
+
+### Decision Tree
+
+`select_strategy(settings: Settings) -> AuthStrategy` in `auth/__init__.py`:
+
+```
+if settings.aws_access_key_id and settings.aws_secret_access_key:
+    base = StaticKeysStrategy(
+        settings.aws_access_key_id,
+        settings.aws_secret_access_key,
+        settings.aws_session_token,   # may be None
+    )
+    if settings.role_arn:
+        return AssumeRoleStrategy(base, settings.role_arn, session_name, settings.aws_region)
+    return base
+
+if settings.role_arn:
+    raise ConfigurationError(
+        "ROLE_ARN requires AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY "
+        "(OIDC-based role assumption ships in Phase 4)"
+    )
+
+raise ConfigurationError(
+    "No valid credential configuration: set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY"
+)
+```
+
+**Phase 4 extension point:** Phase 4 inserts an OIDC check before the static-keys check:
+```
+if settings.oidc_audience and settings.role_arn:
+    return OidcWebIdentityStrategy(...)
+```
+The Phase 2 `select_strategy` must NOT check for `oidc_audience` — that field does not exist in
+`Settings` yet. Leave a `# Phase 4: insert OIDC check here` comment.
+
+### Session Name
+
+`Settings.session_name` already has a default of `"BitbucketPipe"`. In Phase 2, the pipe should
+prefer the value from Bitbucket's environment if available:
+
+```python
+import os
+import uuid
+
+def _derive_session_name(settings: Settings) -> str:
+    if settings.session_name != "BitbucketPipe":
+        # User explicitly set SESSION_NAME — honour it
+        return settings.session_name
+    # Try Bitbucket-provided identifiers
+    for env_var in ("BITBUCKET_PIPELINE_UUID", "BITBUCKET_BUILD_NUMBER"):
+        val = os.environ.get(env_var)
+        if val:
+            clean = val.replace("{", "").replace("}", "")
+            return f"aws-eks-helm-deploy-{clean}"[:64]  # STS session name max 64 chars
+    return f"aws-eks-helm-deploy-{uuid.uuid4()}"
+```
+
+AWS `RoleSessionName` has a max length of 64 characters and allows alphanumeric, `=`, `,`, `.`,
+`@`, `-`, `_`. Truncate with `[:64]` and verify the value matches `[\w+=,.@-]+` — `uuid4` values
+contain only hex digits and hyphens, so they are always valid. `[ASSUMED: 64-char limit from AWS
+IAM docs; verify against docs.aws.amazon.com/IAM/latest/APIReference/API_AssumeRole.html]`
+
+### AssumeRoleStrategy Duration and ExternalId
+
+- **Duration:** Use the AWS default (`DurationSeconds` omitted from `assume_role` call = 3600s / 1h)
+- **ExternalId:** Out of scope for Phase 2. Leave a comment: `# ExternalId: Phase 2 deferred — see AUTH-NEXT`
+- **MFA:** Out of scope
+
+### AWS_SESSION_TOKEN on base credentials
+
+`StaticKeysStrategy` accepts `session_token: str | None`. When `AWS_SESSION_TOKEN` is set in
+`Settings`, the static-key credentials already represent temporary credentials (from a prior
+`GetSessionToken` or `AssumeRole`). These can still be used as the base for a further
+`AssumeRoleStrategy`. STS accepts temporary credentials as the source for `AssumeRole` (subject to
+the role's trust policy). No special code path is needed.
+
+---
+
+## F. awscli Removal Verification
+
+### Current State (Phase 1 already clean)
+
+`pyproject.toml` confirmed (read from disk):
+- `awscli` is **NOT** present in `dependencies` or `dependency-groups` — no removal needed
+- `boto3 ~= 1.43` is already in `dependencies`
+- `moto[eks,sts] ~= 5.2` is already in `dev` dependency-group
+- `boto3-stubs[eks,sts]` is already in `dev` dependency-group
+
+`Dockerfile` confirmed (read from disk):
+- No `apt-get install awscli` in any stage
+- No `pip install awscli` in any stage
+- The `from awscli.customizations.eks.get_token import STSClientFactory, TokenGenerator` import
+  from v1's `pipe/pipe.py` line 20 is NOT present in `src/aws_eks_helm_deploy/`
+
+`[VERIFIED: read pyproject.toml and Dockerfile from disk]`
+
+### Verification Commands (for acceptance test)
+
+```bash
+# Confirm no awscli layer in built image
+docker history <image>:<tag> | grep -i awscli
+# Expected: no output
+
+# Confirm awscli is not importable inside the container
+docker run --rm <image>:<tag> python -c "import awscli" 2>&1 | grep "No module named"
+# Expected: ModuleNotFoundError: No module named 'awscli'
+```
+
+### Image Size (v1 → v2 reduction)
+
+The ROADMAP claims "> 100 MB reduction". awscli v1 is approximately 100-120 MB installed.
+`python:3.13-slim-bookworm` base image is smaller than v1's `python:3-alpine` + awscli combined.
+The SIZE claim should be verified at build time via:
+
+```bash
+docker images <image>:<tag> --format "{{.Size}}"
+```
+
+The Phase 1 Dockerfile already lacks awscli; the size reduction is a v1-to-v2 delta, not a
+Phase 2 change. Document this clearly in the acceptance test: the v1 reference image
+(`yvesvogl/aws-eks-helm-deploy:1.3.0`) must be pulled to measure the delta. `[ASSUMED: 100 MB
+reduction from general knowledge of awscli package size; needs runtime measurement for exact value]`
+
+---
+
+## G. Test Strategy
+
+### Unit Tests (must achieve 100% line+branch coverage on auth/ and aws/ modules)
+
+**Framework:** pytest 9.1 with `@mock_aws` from moto 5.2.2 (single unified decorator for all AWS
+services — no service-specific `@mock_sts` or `@mock_iam` in moto 5.x).
+`[VERIFIED: moto 5.2.2 installed in project venv; mock_aws confirmed as the correct import]`
+
+**Required test import:**
+```python
+from moto import mock_aws
+import boto3
+```
+
+**Coverage targets per module:**
+
+`tests/unit/test_auth_base.py`:
+- `AwsCredentials.__repr__` masks secret: assert `"secret"` not in `repr(creds)`
+- `AwsCredentials.__repr__` shows last-4 of access key
+- `AwsCredentials.to_boto3_kwargs()` without session_token: no `aws_session_token` key
+- `AwsCredentials.to_boto3_kwargs()` with session_token: `aws_session_token` key present
+- `AwsCredentials` frozen: `dataclasses.FrozenInstanceError` on mutation attempt
+- `AuthStrategy` Protocol isinstance check via `runtime_checkable`
+
+`tests/unit/test_static_keys.py`:
+- Happy path: `get_credentials()` returns expected `AwsCredentials`
+- `session_token=None` default
+- `session_token` passes through when set
+
+`tests/unit/test_assume_role.py` (requires `@mock_aws`):
+- Happy path: `get_credentials()` returns `AwsCredentials` with `session_token` set
+- STS `ClientError` → `AuthenticationError` with exit code 2
+- Delegation: base strategy's `get_credentials()` is called to obtain base credentials
+
+`tests/unit/test_auth_select.py`:
+- Static keys only → `StaticKeysStrategy`
+- Static keys + ROLE_ARN → `AssumeRoleStrategy`
+- ROLE_ARN only (no static keys) → `ConfigurationError`
+- No credentials → `ConfigurationError`
+- AWS_SESSION_TOKEN present in static keys → passes through (no error)
+
+`tests/unit/test_eks_token.py` (requires `@mock_aws`):
+- Token starts with `"k8s-aws-v1."`
+- Token contains no `=` padding
+- Decoded URL has `X-Amz-Expires=60`
+- Decoded URL contains `x-k8s-aws-id` in `X-Amz-SignedHeaders`
+- Decoded URL `Action` is `GetCallerIdentity`
+- Decoded URL hostname is `sts.{region}.amazonaws.com` (not `sts.amazonaws.com`)
+- Wrong cluster name produces different token (base64url changes)
+- Different region produces different endpoint in URL
+
+**moto presigned URL note:** Confirmed that moto 5.2.2 generates valid presigned URLs for STS
+under `@mock_aws` — the URL is generated by botocore's credential signing logic, which runs
+locally without hitting the actual AWS endpoint. `[VERIFIED: tested in project venv]`
+
+### Integration Tests (kind cluster)
+
+The ROADMAP requires "a kind-backed integration test proves `StaticKeysStrategy` + `AssumeRoleStrategy`
+produce a kubeconfig that helm accepts."
+
+**Limitation:** moto cannot simulate a real kube-apiserver EKS auth webhook. Real EKS cluster
+testing requires actual AWS credentials. The integration test for Phase 2 must scope to what is
+testable on a local kind cluster:
+
+**What kind can test:**
+- `StaticKeysStrategy` produces valid `AwsCredentials` that are used to configure a boto3 session
+- The token format is structurally correct (token can be placed in a kubeconfig and helm can parse it)
+- helm connectivity to the kind cluster (already wired in Phase 1) is not broken
+
+**What kind cannot test:**
+- The STS `GetCallerIdentity` presigned URL being accepted by a real EKS webhook (requires AWS)
+- The ARN-to-Kubernetes-principal mapping (requires aws-auth ConfigMap or access entries)
+
+**Recommended scope for Phase 2 integration test:**
+```python
+# tests/integration/test_auth_smoke.py
+@pytest.mark.integration
+def test_static_keys_produce_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """StaticKeysStrategy wraps env vars into AwsCredentials without AWS calls."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    settings = Settings()
+    strategy = select_strategy(settings)
+    creds = strategy.get_credentials()
+    assert creds.access_key_id == "AKIAIOSFODNN7EXAMPLE"
+    assert "secret" not in repr(creds)
+
+@pytest.mark.integration
+def test_eks_token_is_structurally_valid(kind_cluster: str) -> None:
+    """EKS token format is parseable (does not require real AWS)."""
+    import base64, urllib.parse
+    import boto3
+    from aws_eks_helm_deploy.aws.eks_token import generate_eks_token
+
+    session = boto3.Session(
+        region_name="eu-central-1",
+        aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    )
+    token = generate_eks_token(session, kind_cluster, "eu-central-1")
+    assert token.startswith("k8s-aws-v1.")
+    assert "=" not in token
+    encoded = token[len("k8s-aws-v1."):]
+    padded = encoded + "=" * (-len(encoded) % 4)
+    url = base64.urlsafe_b64decode(padded).decode()
+    qs = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(url).query))
+    assert qs.get("X-Amz-Expires") == "60"
+    assert "x-k8s-aws-id" in qs.get("X-Amz-SignedHeaders", "")
+```
+
+---
+
+## H. Package Legitimacy Audit
+
+All packages required for Phase 2 are already declared in `pyproject.toml` (Phase 1 delivered
+them). No new packages are introduced in Phase 2.
+
+| Package | Registry | Maintainer | Version (installed) | License | Verdict | Disposition |
+|---------|----------|------------|---------------------|---------|---------|-------------|
+| `boto3` | PyPI | Amazon Web Services | 1.43.31 | Apache-2.0 | OK | Approved — already in `dependencies` |
+| `botocore` | PyPI | Amazon Web Services | 1.43.31 | Apache-2.0 | OK | Approved — transitive of boto3 |
+| `moto[eks,sts]` | PyPI | getmoto/moto | 5.2.2 | Apache-2.0 | OK | Approved — already in `dev` dep-group |
+| `boto3-stubs[eks,sts]` | PyPI | youtype (Vlad Emelianov) | 1.43.0 | MIT | OK | Approved — already in `dev` dep-group |
+| `pytest-mock` | PyPI | pytest-dev | 3.15.1 | MIT | OK | Approved — already in `dev` dep-group |
+
+`[VERIFIED: all versions confirmed by pip show in project venv; maintainers confirmed against PyPI project URLs]`
+
+**Packages removed:** `awscli` was never in `pyproject.toml` — nothing to remove.
+**New packages to install:** None. Phase 2 is purely implementation.
+
+---
+
+## I. Threat Model Template
+
+STRIDE analysis for Phase 2 scope only. The planner should copy this into per-plan security
+acceptance criteria.
+
+| Threat | STRIDE Category | Asset | Standard Mitigation | Implemented In |
+|--------|----------------|-------|---------------------|----------------|
+| Presigned URL tampered in transit (MITM) | Tampering | EKS bearer token | SigV4 HMAC: URL signature covers all included headers; tampering invalidates signature | STS SigV4 (built into botocore) |
+| Credential values leaked to logs | Information Disclosure | `aws_secret_access_key`, `session_token` | `CREDENTIAL_BLOCKLIST` in `logging.py`; `AwsCredentials.__repr__` shows `<redacted>`; never bind raw creds to structlog context | `logging.py` + `auth/base.py` |
+| ROLE_ARN assumption to unintended account | Elevation of Privilege | Assumed-role permissions | Trust policy on the IAM role (AWS-side control); pipe validates ROLE_ARN syntax before calling STS | `auth/__init__.py::select_strategy` |
+| Supply-chain attack via boto3/moto | Tampering / Repudiation | Dependency graph | `uv.lock` pins exact hashes; `pip-audit` CI gate; both packages are owned by major orgs (Amazon, getmoto) | `uv.lock` + `.github/workflows/ci.yml` (Phase 6) |
+| Credentials set in env vars readable by other processes | Information Disclosure | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | These are set by the Bitbucket pipeline runner per-step; not written to disk by the pipe; pipe scope is single-invocation | Platform control (Bitbucket) |
+| Session token expiry causing helm to fail mid-run | Denial of Service | Helm upgrade action | Tokens are fetched at invocation start; STS assumed-role tokens default to 1h (plenty for one `helm upgrade`); no token refresh path needed | Design |
+
+**Out of scope for Phase 2:**
+- IAM role trust policy misconfiguration (AWS-side, documented in Phase 4 IAM template — AUTH-05)
+- OIDC token validation (Phase 4)
+- Log masking of rendered Secrets in helm output (Phase 5 — SEC-06)
+
+---
+
+## J. Suggested Plan Breakdown
+
+The planner should decompose Phase 2 into three waves based on the dependency DAG between modules.
+
+### Wave 1 — Value Objects and Pure Logic (no boto3 network calls; no moto needed)
+
+**Plan J-1:** `auth/base.py` — `AuthStrategy` Protocol + `AwsCredentials` dataclass
+- File: `src/aws_eks_helm_deploy/auth/__init__.py` (empty placeholder)
+- File: `src/aws_eks_helm_deploy/auth/base.py` — Protocol + dataclass
+- Test: `tests/unit/test_auth_base.py` — all `AwsCredentials` coverage + Protocol isinstance test
+- Zero external dependencies; passes with `pytest -m unit`
+
+**Plan J-2:** `aws/eks_token.py` — EKS token generation
+- File: `src/aws_eks_helm_deploy/aws/__init__.py` (empty placeholder)
+- File: `src/aws_eks_helm_deploy/aws/eks_token.py` — `generate_eks_token(session, cluster_name, region)`
+- Test: `tests/unit/test_eks_token.py` — structural token properties under `@mock_aws`
+- Dependency: `auth/base.py` (for `AwsCredentials` used in session construction in later waves)
+
+These two plans can ship in parallel since they have no inter-dependency.
+
+### Wave 2 — Strategy Implementations (depend on `base.py`; require `@mock_aws` for assume-role)
+
+**Plan J-3:** `auth/static_keys.py` — `StaticKeysStrategy`
+- File: `src/aws_eks_helm_deploy/auth/static_keys.py`
+- Test: `tests/unit/test_static_keys.py`
+- Dependency: Wave 1 (`auth/base.py`)
+
+**Plan J-4:** `auth/assume_role.py` — `AssumeRoleStrategy`
+- File: `src/aws_eks_helm_deploy/auth/assume_role.py`
+- Test: `tests/unit/test_assume_role.py` (requires `@mock_aws`)
+- Dependencies: Wave 1 (`auth/base.py`), Wave 2 (`auth/static_keys.py` or any `AuthStrategy`-conforming base)
+
+Plans J-3 and J-4 can ship in parallel since `AssumeRoleStrategy` depends on the `AuthStrategy`
+Protocol (defined in Wave 1), not on `StaticKeysStrategy` specifically.
+
+### Wave 3 — Composition and Wire-In (depend on all of Wave 2)
+
+**Plan J-5:** `auth/__init__.py::select_strategy()` + `cli.py` wire-in
+- File: `src/aws_eks_helm_deploy/auth/__init__.py` — `select_strategy(settings: Settings) -> AuthStrategy`
+- Edit: `src/aws_eks_helm_deploy/cli.py` — call `select_strategy(settings)` in `main()`, bind `auth_strategy` name to structlog context via `bind_safe_context(auth_strategy=type(strategy).__name__)`
+- Test: `tests/unit/test_auth_select.py` — all decision-tree branches
+- Dependencies: all of Wave 2
+
+**Plan J-6:** Integration test + acceptance verification
+- Test: `tests/integration/test_auth_smoke.py`
+- Verify: `docker history` check; image size delta measurement
+- Dependencies: Wave 3 (all modules complete)
+
+---
+
+## K. Module File Layout
+
+```
+src/aws_eks_helm_deploy/
+├── auth/
+│   ├── __init__.py          # select_strategy(settings) — Wave 3
+│   ├── base.py              # AuthStrategy Protocol + AwsCredentials — Wave 1
+│   ├── static_keys.py       # StaticKeysStrategy — Wave 2
+│   └── assume_role.py       # AssumeRoleStrategy — Wave 2
+└── aws/
+    ├── __init__.py          # empty — Wave 1
+    └── eks_token.py         # generate_eks_token() — Wave 1
+
+tests/unit/
+├── test_auth_base.py        # Wave 1
+├── test_eks_token.py        # Wave 1
+├── test_static_keys.py      # Wave 2
+├── test_assume_role.py      # Wave 2
+└── test_auth_select.py      # Wave 3
+
+tests/integration/
+└── test_auth_smoke.py       # Wave 3
+```
+
+---
+
+## L. Coding Conventions (from Phase 1 PATTERNS.md)
+
+All new modules must follow the established Phase 1 patterns:
+
+1. `from __future__ import annotations` as first non-docstring line in every `src/` file
+2. Docstrings on all public classes and functions (ruff `ANN` rule is enforced)
+3. Raise typed `PipeError` subclasses; catch only in `cli.main()`
+4. Never call `os.environ.get(...)` outside `settings.py`
+5. Never bind raw credential values to structlog context — use `bind_safe_context()` only
+6. `@pytest.mark.unit` is the default tier (via `addopts = "-m 'unit'"` in `pyproject.toml`)
+7. Integration tests need `@pytest.mark.integration` decorator
+8. mypy strict mode: `src/` must pass `mypy --strict src/` — annotate all function signatures
+
+**ruff rule note:** The ruff config includes `"BLE"` (blind except) and `"S"` (bandit). Ensure
+`except botocore.exceptions.ClientError` is always followed by re-raising as a `PipeError`
+subclass (not swallowed). The `"ANN"` rule requires return type annotations on all public methods.
+
+---
+
+## References
+
+### Primary Sources
+
+- **awscli EKS get_token source** — `https://github.com/aws/aws-cli/blob/develop/awscli/customizations/eks/get_token.py`
+  Authoritative Python implementation. Defines `TOKEN_PREFIX`, `K8S_AWS_ID_HEADER`, `URL_TIMEOUT`,
+  `TOKEN_EXPIRATION_MINS`, `STSClientFactory` event-injection pattern, `TokenGenerator` class.
+
+- **aws-iam-authenticator Go source** — `https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/pkg/token/token.go`
+  Reference Go implementation. Confirms `v1Prefix = "k8s-aws-v1."`, `clusterIDHeader = "x-k8s-aws-id"`,
+  `requestPresignParam = 60`, `base64.RawURLEncoding` (no padding).
+
+- **moto getting started** — `https://docs.getmoto.org/en/latest/docs/getting_started.html`
+  Confirms `from moto import mock_aws` as the correct moto 5.x import; `@mock_aws` as unified decorator.
+
+- **moto STS docs** — `https://docs.getmoto.org/en/latest/docs/services/sts.html`
+  Confirms `assume_role`, `get_caller_identity` supported. Presigned URL generation works via
+  botocore local signing (verified experimentally).
+
+- **STS GetCallerIdentity API** — `https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html`
+  Confirms no IAM permissions required for GetCallerIdentity.
+
+### Verified in Project Venv
+
+- boto3 1.43.31 + botocore 1.43.31: `generate_presigned_url` signature confirmed
+- moto 5.2.2: `@mock_aws` works for STS assume_role, get_caller_identity, EKS describe_cluster,
+  and presigned URL generation
+- `mypy_boto3_sts.type_defs.CredentialsTypeDef` fields: `AccessKeyId`, `SecretAccessKey`,
+  `SessionToken`, `Expiration`
+- EKS token generation via botocore event injection: confirmed `X-Amz-SignedHeaders=host;x-k8s-aws-id`
+  and `X-Amz-Expires=60` in generated URL
+
+---
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | "Golden test" means structural equivalence (token format properties), not byte-for-byte comparison | A | Low — bytes can never be equal across invocations (timestamp + HMAC vary) |
+| A2 | RoleSessionName max length is 64 chars | E | Low — truncation to [:64] is safe regardless |
+| A3 | v1 awscli adds ~100-120 MB to the image | F | Low — image size claim is informational, measured at build time |
+| A4 | `dataclass(frozen=True)` cold-import is ~40-60 ms cheaper than Pydantic | D | Negligible — this is a style justification, not a performance gate |
+
+---
+
+## Confidence Breakdown
+
+| Area | Level | Reason |
+|------|-------|--------|
+| EKS token algorithm | HIGH | Verified by running exact code in project venv; confirmed against awscli upstream source |
+| AuthStrategy Protocol design | HIGH | Verified Protocol structural subtyping, frozen dataclass, repr masking in project venv |
+| moto 5.x API | HIGH | Confirmed `mock_aws` decorator, STS and EKS support in installed moto 5.2.2 |
+| boto3 event injection pattern | HIGH | Verified generates correct `X-Amz-SignedHeaders` including `x-k8s-aws-id` |
+| Package legitimacy | HIGH | All packages already installed and validated in Phase 1 |
+| Integration test scope | MEDIUM | kind-cluster test coverage of auth is necessarily limited without real AWS |
+| Image size reduction claim | MEDIUM | Structural claim verified (awscli absent from Dockerfile); exact MB requires build-time measurement |

--- a/.planning/phases/02-aws-layer-auth-foundation/02-VALIDATION.md
+++ b/.planning/phases/02-aws-layer-auth-foundation/02-VALIDATION.md
@@ -1,0 +1,147 @@
+---
+phase: 2
+slug: aws-layer-auth-foundation
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-06-17
+---
+
+# Phase 2 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | pytest 9.1.x (inherited from Phase 1) |
+| **Mocking** | moto 5.2.x `@mock_aws` for STS / EKS; `pytest-mock` for boto3 client patching |
+| **Config file** | `pyproject.toml` (no Phase 2 modifications — Phase 1 already wired `--cov-fail-under=100`) |
+| **Quick run command** | `uv run pytest -q --no-cov` (unit tier, no gate; < 5s including moto warmup) |
+| **Full suite command** | `uv run pytest && uv run pytest -m integration --no-cov && uv run pytest -m acceptance --no-cov` |
+| **Estimated runtime** | unit ~5s (moto adds ~1s warm-up) · integration ~30s (kind reuse from Phase 1 fixture) · acceptance ~60s (unchanged) |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `uv run pytest -q --no-cov` (~5s; unit tier, no gate) — verifies the freshly committed module + existing 33+ Phase 1 tests stay green.
+- **After every plan wave merge:** Run the full suite: `uv run pytest` (with the 100% gate) + `pytest -m integration --no-cov` (when kind is installed).
+- **Before `/gsd-verify-work`:** Full suite green AND `uv run mypy --strict src` AND `uv run ruff check src tests` AND `uv run ruff format --check src tests` AND `uv run pre-commit run --all-files` ALL exit 0.
+- **Max feedback latency:** < 5s per task commit (unit-tier quick run); < 90s per wave merge.
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | SC | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|----|------------|-----------------|-----------|-------------------|-------------|--------|
+| 02-1-01 | 02-01 | 1 | AUTH-07 | SC1 | T-02-01-02 | EksTokenError surfaces public STS error codes only — no credential leak | unit | `uv run pytest -m unit -q tests/unit/test_errors.py --no-cov` | ❌ W0 | ⬜ pending |
+| 02-1-02 | 02-01 | 1 | AUTH-07 | SC2 (structural; see deviation), SC3 | T-02-01-01, T-02-01-03, T-02-01-04 | Regional STS endpoint enforced; SigV4 signature covers `x-k8s-aws-id`; awscli import absent (audit grep gate) | unit | `uv run pytest -m unit -q tests/unit/test_eks_token.py --cov=aws_eks_helm_deploy.aws.eks_token --cov-branch --cov-fail-under=100 --no-header && grep -RIn '^\\s*from awscli' src/ \| awk 'NR>0{exit 1}'` | ❌ W0 | ⬜ pending |
+| 02-2-01 | 02-02 | 1 | AUTH-01 | SC1, SC4 | T-02-02-01, T-02-02-02, T-02-02-03 | AwsCredentials.\_\_repr\_\_ masks secret; to_boto3_kwargs collides with CREDENTIAL_BLOCKLIST (raises ValueError when fed into bind_safe_context); frozen dataclass | unit | `uv run pytest -m unit -q tests/unit/test_auth_base.py --cov=aws_eks_helm_deploy.auth.base --cov-branch --cov-fail-under=100 --no-header` | ❌ W0 | ⬜ pending |
+| 02-3-01 | 02-03 | 2 | AUTH-01 | SC1, SC4 | (delegated to T-02-02-*) | StaticKeysStrategy is pure value-object wrapper — no AWS imports; satisfies AuthStrategy Protocol structurally | unit | `uv run pytest -m unit -q tests/unit/test_static_keys.py --cov=aws_eks_helm_deploy.auth.static_keys --cov-branch --cov-fail-under=100 --no-header` | ❌ W0 | ⬜ pending |
+| 02-3-02 | 02-03 | 2 | AUTH-02 | SC1, SC4 | T-02-03-01, T-02-03-02, T-02-03-04 | Regional STS endpoint enforced; ClientError → AuthenticationError; base strategy delegated to via .get_credentials() | unit | `uv run pytest -m unit -q tests/unit/test_assume_role.py --cov=aws_eks_helm_deploy.auth.assume_role --cov-branch --cov-fail-under=100 --no-header` | ❌ W0 | ⬜ pending |
+| 02-4-01 | 02-04 | 3 | AUTH-01, AUTH-02 | SC1 | T-02-04-02, T-02-04-03 | select_strategy decision tree covers all four branches; _derive_session_name enforces 64-char limit and IAM regex | unit | `uv run pytest -m unit -q tests/unit/test_auth_select.py --cov=aws_eks_helm_deploy.auth --cov-branch --cov-fail-under=100 --no-header` | ❌ W0 | ⬜ pending |
+| 02-4-02 | 02-04 | 3 | AUTH-01, AUTH-02 | SC1; closes Phase 1 OBS-01 PARTIAL | T-02-04-01, T-02-04-04, T-02-04-05 | bind_safe_context called with auth_strategy class name only (never credential values); ConfigurationError surfaces via pipe.fail; structlog emits ≥1 JSON line on stderr | unit | `uv run pytest -m unit -q tests/unit/test_cli.py --cov=aws_eks_helm_deploy.cli --cov-branch --cov-fail-under=100 --no-header && uv run pytest -q` | ❌ W0 | ⬜ pending |
+| 02-4-03 | 02-04 | 3 | AUTH-07 (end-to-end shape) | SC4 | (delegated to T-02-01-*) | End-to-end token shape on kind cluster name — no real EKS webhook validation (out of scope per RESEARCH G) | integration | `uv run pytest -m integration -q --no-cov tests/integration/test_auth_smoke.py` | ❌ W0 | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+**Wave dependency notes:**
+- **Wave 1 (parallel):** 02-01 + 02-02 — no inter-dependency; can ship in either order.
+- **Wave 2 (depends on Wave 1):** 02-03 depends on 02-02 (`auth/base.py` exports). 02-03 does NOT depend on 02-01 (independent file paths).
+- **Wave 3 (depends on Wave 1 + Wave 2):** 02-04 depends on 02-01 (`generate_eks_token`), 02-02 (Protocol + dataclass), AND 02-03 (concrete strategies). Composition root.
+- **File-overlap check:** No same-wave plans share any `files_modified` entry. `errors.py` is modified only by 02-01 (Wave 1). `settings.py` may be modified only by 02-04 (Wave 3) — to add `aws_session_token` field if not already present.
+
+**Strict ordering enforcement:**
+- 02-04 Task 02-4-02 (cli wire-in) modifies `cli.py` — this is the same file Phase 1's PLAN-01 created. The Phase 1 placeholder action message text changes; no behavioral break.
+- 02-04 Task 02-4-02 also modifies `tests/unit/test_cli.py` — existing 4 Phase 1 tests get a fixture-based short-circuit; their assertions remain valid.
+
+---
+
+## Wave 0 Requirements
+
+All Phase 2 test infrastructure builds on Phase 1's foundation (test tiers, conftest, kind fixture). New files created BEFORE tests can be exercised:
+
+- [ ] `src/aws_eks_helm_deploy/aws/__init__.py` (Plan 02-01, Task 02-1-01) — required before `test_eks_token.py` can import.
+- [ ] `src/aws_eks_helm_deploy/aws/eks_token.py` (Plan 02-01, Task 02-1-02) — required before any unit OR integration test of token generation.
+- [ ] `src/aws_eks_helm_deploy/errors.py` (Plan 02-01, Task 02-1-01) — EksTokenError needed before token-gen error tests.
+- [ ] `src/aws_eks_helm_deploy/auth/__init__.py` (Plan 02-02 empty placeholder; Plan 02-04 fills it) — package marker required.
+- [ ] `src/aws_eks_helm_deploy/auth/base.py` (Plan 02-02, Task 02-2-01) — Protocol + dataclass required by 02-03 and 02-04 modules.
+- [ ] `src/aws_eks_helm_deploy/auth/static_keys.py` (Plan 02-03, Task 02-3-01) — required by 02-04 select_strategy.
+- [ ] `src/aws_eks_helm_deploy/auth/assume_role.py` (Plan 02-03, Task 02-3-02) — required by 02-04 select_strategy.
+- [ ] `tests/unit/test_eks_token.py` (Plan 02-01, Task 02-1-02) — first to land; covers AUTH-07 unit surface.
+- [ ] `tests/unit/test_auth_base.py` (Plan 02-02, Task 02-2-01) — covers AUTH-01 Protocol/dataclass surface.
+- [ ] `tests/unit/test_static_keys.py` (Plan 02-03, Task 02-3-01) — covers AUTH-01 strategy surface.
+- [ ] `tests/unit/test_assume_role.py` (Plan 02-03, Task 02-3-02) — covers AUTH-02 strategy surface.
+- [ ] `tests/unit/test_auth_select.py` (Plan 02-04, Task 02-4-01) — covers AUTH-01 + AUTH-02 decision-tree surface.
+- [ ] `tests/integration/test_auth_smoke.py` (Plan 02-04, Task 02-4-03) — covers AUTH-07 end-to-end shape.
+
+Existing Phase 1 infrastructure REUSED (no new files):
+- `tests/conftest.py` (auto-mark hook).
+- `tests/integration/conftest.py::kind_cluster` (session fixture, reused by 02-4-03's Test 2).
+- `tests/acceptance/conftest.py::built_image` (NOT reused in Phase 2 — acceptance tier is unchanged; Phase 1's three acceptance tests still pass).
+- `pyproject.toml` `[tool.pytest.ini_options].addopts` already has `--cov-fail-under=100` — Phase 2 inherits the gate.
+
+When all source files in 02-01..04 have merged AND their corresponding test files exist AND `pytest -q` exits 0 at 100% coverage, the Phase 2 validation contract is fully active.
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| AUTH-07 absence of `awscli` import in source (audit grep) | AUTH-07 | A unit test for "the codebase contains no `awscli` import" is structurally a code-grep; it does not add unit-test value. Surfaced here as the canonical gate. | `grep -RIn '\\bawscli\\b' src/ \|\| echo "OK: no awscli reference in src/"`. Expected: NO matching lines. If any line matches, AUTH-07 is violated. |
+| AUTH-07 absence of `awscli` from the built Docker image | AUTH-07 (image side) | Phase 1 verified no `awscli` in Dockerfile via the IMAGE-* gates; Phase 2 inherits. A live-image check is host-dependent. | `docker run --rm aws-eks-helm-deploy:dev python -c "import awscli" 2>&1 \| grep "No module named"` — expects ModuleNotFoundError. |
+| Phase 1 OBS-01 PARTIAL closure | OBS-01 (Phase 1 carry-over) | Manual smoke against Docker confirms the JSON-line emission added by Task 02-4-02. | `LOG_FORMAT=json AWS_ACCESS_KEY_ID=AKIA-FAKE AWS_SECRET_ACCESS_KEY=fake docker run --rm -e LOG_FORMAT=json -e AWS_ACCESS_KEY_ID=AKIA-FAKE -e AWS_SECRET_ACCESS_KEY=fake-secret -e CLUSTER_NAME=test aws-eks-helm-deploy:dev 2>&1 \| python3 -c "import sys, json; [json.loads(l) for l in sys.stdin if l.strip()]"` — exits 0 once at least one JSON line is emitted. |
+| Integration test on kind | AUTH-07 end-to-end | Requires kind + docker locally; CI gating lands in Phase 6. | `uv run pytest -m integration -q --no-cov tests/integration/test_auth_smoke.py` — both tests pass; cluster is created+torn down by Phase 1 fixture. |
+| `RoleSessionName` truncation visible in STS CloudTrail | AUTH-02 (operational) | Requires a real AWS account and CloudTrail access; not gateable in CI. | Manual smoke once Phase 2 ships in a dev/staging Bitbucket pipeline against a real EKS cluster. The session name should appear in CloudTrail under the assumed-role event and should be ≤ 64 chars matching `[\\w+=,.@-]+`. |
+
+*All other phase behaviors have automated verification.*
+
+---
+
+## ROADMAP / RESEARCH Deviation Surface
+
+This phase ships THREE documented deviations from the ROADMAP wording. They are intentional and surfaced here so the phase-checker / plan-checker can verify them up-front:
+
+1. **ROADMAP Phase 2 SC2 "byte-equal" wording** is structurally impossible (timestamp + HMAC vary per call). Replaced with **structural equivalence** per RESEARCH Section A. (See `02-01-PLAN.md <deviations>` section.)
+2. **`EksTokenError.exit_code = 3`** is intentionally shared with `ClusterAccessError` (both are EKS-reach failures from the consumer's perspective). Distinct exit codes would not add consumer value. (See `02-01-PLAN.md <deviations>` section.)
+3. **Phase 1 OBS-01 PARTIAL gap** is closed in Phase 2 by adding `logger.info("auth strategy selected", auth_strategy=...)` to `cli.py`. The Phase 1 verifier's "human_needed" verdict can be retroactively resolved when Phase 2 ships. (See `02-04-PLAN.md <deviations>` Deviation 2.)
+
+The phase-checker / phase-verifier MUST acknowledge these deviations before flagging them as gaps in `02-VERIFICATION.md`.
+
+---
+
+## Coverage Roll-Up
+
+Phase 2 adds the following modules; all MUST hit 100% line + 100% branch by the end of the phase (per the active `--cov-fail-under=100` gate from Phase 1):
+
+| Module | Owner Plan | Coverage Target | Branch Coverage Note |
+|--------|------------|------------------|----------------------|
+| `src/aws_eks_helm_deploy/aws/__init__.py` | 02-01 | 100% (trivial) | No branches. |
+| `src/aws_eks_helm_deploy/aws/eks_token.py` | 02-01 | 100% line + 100% branch | Both `ClientError` and `NoCredentialsError` branches must be exercised. |
+| `src/aws_eks_helm_deploy/auth/__init__.py` | 02-02 (empty) → 02-04 (filled) | 100% line + 100% branch | All four `select_strategy` decision branches + all four `_derive_session_name` fallback paths. |
+| `src/aws_eks_helm_deploy/auth/base.py` | 02-02 | 100% line + 100% branch | The `len(access_key_id) < 4` branch in `__repr__` must be exercised. |
+| `src/aws_eks_helm_deploy/auth/static_keys.py` | 02-03 | 100% line + 100% branch | Trivial — pure value-object wrapper. |
+| `src/aws_eks_helm_deploy/auth/assume_role.py` | 02-03 | 100% line + 100% branch | Both `ClientError` and `NoCredentialsError` branches must be exercised. |
+| `src/aws_eks_helm_deploy/cli.py` | extended by 02-04 | 100% line + 100% branch | New `except PipeError` on `select_strategy` must be exercised. |
+| `src/aws_eks_helm_deploy/errors.py` | extended by 02-01 | 100% (existing 100% + new EksTokenError class) | New class tested in `test_errors.py`. |
+| `src/aws_eks_helm_deploy/settings.py` | conditionally extended by 02-04 | 100% (already at 100% from Phase 1; new `aws_session_token` field is field-declaration only, no branch) | If the field is already present from Phase 1 (planner expects so), no coverage change. |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify OR documented Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify (8 tasks across 4 plans, every task has an automated verify)
+- [ ] Wave 0 covers all MISSING references (see Wave 0 Requirements above)
+- [ ] No watch-mode flags (no `--watch`, no `pytest-watch`)
+- [ ] Feedback latency < 5s per task quick-run (verified locally: moto warmup ~1s + test execution < 4s)
+- [ ] All three documented deviations are surfaced to the phase-checker (this file's "ROADMAP / RESEARCH Deviation Surface" section)
+- [ ] `nyquist_compliant: true` to be set after Wave 3 lands and the full unit + integration suites pass
+
+**Approval:** pending

--- a/.planning/proposals/scorecard-hardening-sprint.md
+++ b/.planning/proposals/scorecard-hardening-sprint.md
@@ -1,0 +1,157 @@
+# Proposal: OpenSSF Scorecard Hardening Sprint
+
+**Status:** Draft for review
+**Author:** Yves Vogl
+**Date:** 2026-06-17
+**Target:** Score ≥ 9/10 at v2.0 tag-cut
+
+## Background
+
+The roadmap already includes Scorecard adoption as **SEC-10 in Phase 6**: a weekly `scorecard.yml` workflow, README badge, target ≥ 8/10. This proposal **raises the bar to ≥ 9/10** by extracting a dedicated hardening sprint instead of folding it into Phase 6's heavy supply-chain workload.
+
+Rationale for separating it:
+1. Phase 6 already carries Cosign + SBOM + Trivy + pip-audit + release-please + multi-arch + Dependabot + PVR — adding Scorecard maxing on top would either delay Phase 6 or leave Scorecard at the minimum-viable level
+2. Most Scorecard checks are independent of Phase 2–5 functional work and can ship in parallel
+3. Some checks (Branch-Protection, SECURITY.md, CodeQL, CII Best Practices badge) are zero-functional-risk and can ship before Phase 1 even merges
+4. Concentrating the focus produces a defendable, externally-visible score quickly
+
+## Current baseline assessment
+
+The 18 Scorecard checks, assessed against the repo as of `HEAD` of `phase/02-aws-layer`:
+
+| # | Check | Status | Current state | Reachable score |
+|---|-------|--------|---------------|-----------------|
+| 1 | Binary-Artifacts | PASS | Only `logo.png`/`logo.pxd`; no executables in tree | 10 |
+| 2 | Branch-Protection | **FAIL** | `main` has no branch protection rules (GitHub API: 404) | 10 — needs setup |
+| 3 | CI-Tests | PASS | `ci.yml` runs pre-commit + tests on push and PR | 10 |
+| 4 | CII-Best-Practices | **FAIL** | No badge registered | 10 — 90-min effort to fill questionnaire |
+| 5 | Code-Review | PARTIAL | Solo project — Yves merges own PRs, no second reviewer | **Capped at ~5/10** without external reviewer |
+| 6 | Contributors | **FAIL** | Solo project, single org | **Capped at 0–3/10** without external contributors |
+| 7 | Dangerous-Workflow | PASS | `ci.yml` uses `pull_request` (not `_target`); no script injection | 10 |
+| 8 | Dependency-Update-Tool | **FAIL** | No `.github/dependabot.yml` (planned SEC-08 Phase 6) | 10 — Phase 6 plan can land early |
+| 9 | Fuzzing | **FAIL** | No fuzz tests | 5–10 — Atheris+Hypothesis on `eks_token.py` is realistic mid-effort |
+| 10 | License | PASS-ish | `LICENSE.txt` is Apache-2.0 but GitHub flags `licenseInfo: "Other"` due to `.txt` extension | 10 — trivial rename to `LICENSE` |
+| 11 | Maintained | PASS | 56 commits last 3 months | 10 |
+| 12 | Packaging | **FAIL** | No GitHub Releases yet (v1.x is on Docker Hub, not as GH release; v2.0 → GHCR in Phase 6) | 10 once Phase 6 release-please ships |
+| 13 | Pinned-Dependencies | PARTIAL | `uv.lock` hashes ✓; GHA pinned by SHA ✓; helm SHA256 ✓; **base images on tags, not digests** | 9–10 once Dockerfile base images get digest-pinned |
+| 14 | SAST | PARTIAL | ruff has security S-rules; no CodeQL/Semgrep | 10 with CodeQL workflow |
+| 15 | Security-Policy | **FAIL** | No `SECURITY.md` | 10 — 30-min write |
+| 16 | Signed-Releases | **FAIL** | No releases yet; Phase 6 plans Cosign | 10 once Phase 6 release pipeline ships |
+| 17 | Token-Permissions | PASS | `ci.yml` has `permissions: contents: read` | 10 |
+| 18 | Vulnerabilities | PARTIAL | pip-audit ignores CVE-2026-25645 (blocked on bpt 6.3.0, with stale-check) | 9 — Scorecard may dock for the ignore; closes when bpt 6.3.0 lands |
+
+**Realistic ceiling for a single-maintainer OSS project:**
+- Code-Review caps at ~5/10 — Scorecard's algorithm rewards multiple distinct reviewers per PR
+- Contributors caps at ~0–3/10 — needs ≥3 distinct GitHub orgs over time
+- Both reflect "is this a healthy multi-stakeholder project" rather than code quality. They cannot be quick-won.
+
+**Reachable weighted score: ~8.5–9.2 / 10** depending on how Scorecard weights Code-Review and Contributors. Targeting **9.0** is ambitious-but-realistic; **8.5** is the safer floor.
+
+## Proposed sprint scope
+
+Split into three tiers by effort and timing:
+
+### Tier 1 — Quick wins, ship before Phase 1 merge (1 sitting, ~2-3 h)
+
+These have zero functional risk and immediately bump the score:
+
+1. **Rename `LICENSE.txt` → `LICENSE`** — fixes GitHub's `licenseInfo: "Other"` flag and the Scorecard License check.
+2. **Add `SECURITY.md`** — defines vulnerability-reporting channel (GitHub Private Vulnerability Reporting, the SEC-09 mechanism). Template: scope, supported-versions table, disclosure timeline (90 days), contact (`Security` tab on GitHub).
+3. **Add `.github/dependabot.yml`** — for `pip` ecosystem (pyproject.toml + uv.lock), `docker` ecosystem (Dockerfile base image digests), `github-actions` ecosystem. Use the SEC-08 commit-prefix convention (`fix(deps):`) already documented in the roadmap.
+4. **Enable Branch Protection on `main`** — require PR, require status check `ci / pre-commit (lint + typecheck + unit + secrets)`, require linear history, dismiss stale reviews, disallow force-push. Solo-developer concession: `Required approving reviews: 0` for now (Code-Review check stays low; that's acceptable).
+5. **Enable GitHub Private Vulnerability Reporting (PVR)** — Settings → Security → Private vulnerability reporting → On. No code change. Links to SECURITY.md.
+6. **Add `CONTRIBUTING.md`** — community-health file. Defines how to file issues, the PR workflow (Conventional Commits, signed commits, `make all` must pass), code-style expectations.
+7. **Add `CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1. Trivial copy.
+8. **Add `CODEOWNERS`** — `* @yves-vogl` for now. Future contributors get auto-assigned reviews. Required by Branch Protection's `Require review from Code Owners` if enabled.
+
+**Estimated bump:** +3 to +4 score points (License 10/10, Security-Policy 10/10, Branch-Protection ≥7/10, Dependency-Update-Tool 10/10).
+
+### Tier 2 — Mid-effort, ship before Phase 6 (parallelizable with Phases 2–5, ~1 day)
+
+1. **OpenSSF Best Practices badge** — register at `bestpractices.coreinfrastructure.org` and answer the 60+ "passing"-tier questions. Apache-2.0 license, public repo, documented contribution flow, CI gate — most answers are already true; this is paperwork. Bumps CII-Best-Practices from 0 → 10.
+2. **CodeQL workflow** — `.github/workflows/codeql.yml`, weekly + on push to main. Python language. Adds SAST coverage beyond ruff's S-rules. Bumps SAST from ~5 → 10.
+3. **Scorecard workflow itself** — bring SEC-10 forward from Phase 6 to this sprint. `.github/workflows/scorecard.yml` runs `ossf/scorecard-action@v2`, uploads SARIF to Code Scanning, README badge linking to `api.securityscorecards.dev`. Without this, the score is not externally visible.
+4. **Dockerfile base-image digest pinning** — pull SEC-03 (currently deferred) forward. `FROM python:3.13-slim-bookworm@sha256:<digest>` and same for `debian:bookworm-slim`. Bumps Pinned-Dependencies from ~7 → 10. Dependabot (from Tier 1) maintains the digests.
+5. **Fix the awscli acceptance gate (Warning 1 from Phase 2 plan-check)** — small acceptance test that proves `awscli` isn't importable in the image. Closes the manual-only gate. Marginal Scorecard impact but closes a soft ROADMAP commitment.
+
+**Estimated bump:** +1.5 to +2 score points (CII 0 → 10, SAST 5 → 10, Pinned-Dependencies 7 → 10).
+
+### Tier 3 — Higher effort, defer to Phase 6 cleanly
+
+These are genuinely Phase 6 scope and shouldn't be hoisted into this sprint:
+
+1. **Signed-Releases via Cosign keyless** — needs the full release pipeline (release-please + GHA OIDC + Cosign keyless signer) to exist. Phase 6 ships this.
+2. **Packaging** — first GitHub Release with attached SBOM / provenance. Phase 6 ships this.
+3. **Fuzzing** — Atheris + Hypothesis for `eks_token.py`'s token parser, `_CommaListEnvSource`'s decode logic. Mid-effort, defensible to defer; could also ship in this sprint as a Tier 2 stretch goal.
+
+### Hard ceiling
+
+These cannot be quick-won without external participation:
+
+- **Code-Review** — requires distinct reviewers on PRs. Adding a CODEOWNERS entry for `@yves-vogl` does not satisfy this; Scorecard wants someone OTHER than the author to approve. Acceptance: solo project, this caps at ~5/10. Can revisit when adesso colleagues or external contributors join.
+- **Contributors** — requires ≥3 distinct GitHub organizations contributing over time. Solo project caps at 0–3/10.
+
+## Recommended Tier 1 + Tier 2 deliverable bundle
+
+If you green-light a focused sprint, the natural deliverable is **a single PR (or 2–3 small PRs)** that adds:
+
+- `LICENSE` (renamed from `LICENSE.txt`)
+- `SECURITY.md`
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `.github/CODEOWNERS`
+- `.github/dependabot.yml` (pip + docker + github-actions, with `fix(deps):` commit prefix)
+- `.github/workflows/codeql.yml` (CodeQL, weekly + on push)
+- `.github/workflows/scorecard.yml` (Scorecard, weekly + on push)
+- `Dockerfile` — base images digest-pinned (`python:3.13-slim-bookworm@sha256:…` + `debian:bookworm-slim@sha256:…`)
+- README badge row updated with Scorecard badge + CII-Best-Practices badge (once registered)
+- One acceptance test for awscli absence
+
+Plus repo-level GitHub UI changes (no code commit, just settings):
+- Enable Branch Protection on `main` (PR required, linear history, status checks)
+- Enable Private Vulnerability Reporting
+- Register OpenSSF Best Practices badge (external — issues a `cii-best-practices` ID)
+
+## Expected outcome
+
+| Check | Before | After Tier 1 + 2 |
+|-------|--------|------------------|
+| Binary-Artifacts | 10 | 10 |
+| Branch-Protection | 0 | 8–9 (solo-dev concession on `required_reviewers=0`) |
+| CI-Tests | 10 | 10 |
+| CII-Best-Practices | 0 | 10 |
+| Code-Review | 0 | 0–5 (capped by solo project) |
+| Contributors | 0 | 0–3 (capped by solo project) |
+| Dangerous-Workflow | 10 | 10 |
+| Dependency-Update-Tool | 0 | 10 |
+| Fuzzing | 0 | 0 (Tier 3) or 5 (Tier 2 stretch) |
+| License | 10 (but flagged) | 10 (clean) |
+| Maintained | 10 | 10 |
+| Packaging | 0 | 0 → 10 after Phase 6 release |
+| Pinned-Dependencies | 7 | 10 |
+| SAST | 5 | 10 |
+| Security-Policy | 0 | 10 |
+| Signed-Releases | 0 | 0 → 10 after Phase 6 |
+| Token-Permissions | 10 | 10 |
+| Vulnerabilities | 9 | 10 (when bpt 6.3.0 lands) |
+
+**Projected aggregate after this sprint: ~8.3 / 10**
+**Projected aggregate after Phase 6 (Packaging + Signed-Releases + Fuzzing add): ~9.0 / 10**
+
+The hard 10/10 is unreachable without multi-org contributors and per-PR external review. That's a project-maturity ceiling, not a hardening gap.
+
+## Decision needed from Yves
+
+1. **Tier-1 standalone PR now** (before Phase 1 merges) — yes/no?
+2. **Tier-2 bundle as a parallel sprint** (during Phase 2/3 execution) — yes/no?
+3. **Fuzzing in Tier 2 stretch or deferred to Phase 6** — preference?
+4. **CII Best Practices badge — do the questionnaire** — yes/no/later?
+5. **Tier-1 + Tier-2 grouping** — one big PR, three small PRs, or fold into existing phase PRs?
+
+## Risks of doing this sprint
+
+- **Branch Protection on `main` will block your own direct pushes** going forward. You're already using PRs (per `tech_standards.md`), so this codifies what you already do.
+- **Dependabot will start opening PRs immediately** — most as `fix(deps):` for base-image digests, weekly for `pip`. Your `feedback_dependency_trust.md` policy is to auto-merge dependabot once CI is green; this will burn through PR cycles but no human attention.
+- **CodeQL** may flag false positives (Python is well-supported but ruff's S-rules already catch most things). Each finding requires triage.
+- **CII Best Practices** questionnaire takes ~90 minutes the first time.
+- **OpenSSF Scorecard score becomes public** — a low initial score (e.g., 6/10 before this sprint completes) is visible on the README badge. Recommend: don't add the badge until the score is ≥ 8.


### PR DESCRIPTION
## Summary

Phase 2 planning artifacts on a clean branch off main. **Replaces closed PR #25** (was stacked on phase/01 which got squash-deleted on merge). Adds the OpenSSF Scorecard hardening proposal as a separate doc commit.

Planning-only — no source code changes. Phase 2 execution waits on user review of these plans.

## Phase 2 goal

Pipe authenticates to AWS via static keys + optional ROLE_ARN assumption through a typed `AuthStrategy` Protocol; EKS tokens via pure boto3; awscli removed. AUTH-01, AUTH-02, AUTH-07.

## Artifacts

- `02-RESEARCH.md` — EKS token wire format verified live in venv, AuthStrategy Protocol prototyped, moto 5.2 patterns confirmed
- **4 PLAN files** (canonical naming `02-NN-PLAN.md`):
  - `02-01-PLAN.md` — `aws/eks_token.py` (pure-boto3 token, AUTH-07)
  - `02-02-PLAN.md` — `auth/base.py`: Protocol + AwsCredentials with masked `__repr__` (AUTH-01)
  - `02-03-PLAN.md` — `auth/static_keys.py` + `auth/assume_role.py` (AUTH-01, AUTH-02)
  - `02-04-PLAN.md` — `select_strategy` composition + cli wire-in + integration smoke + `Settings.aws_session_token` (AUTH-01, AUTH-02, AUTH-07)
- `02-VALIDATION.md` — per-task validation matrix
- `02-PLAN-CHECK.md` — plan-checker verdict
- `.planning/proposals/scorecard-hardening-sprint.md` — separate proposal doc (Tier-1 already shipped in #26; Tier-2 follow-up PR pending)

## Plan-checker verdict

**APPROVED-WITH-WARNINGS** — 0 blockers, 3 non-blocking warnings (SC3 manual-only gate, SC4 kubeconfig deferred to Phase 3, executor mocking-pattern hint). Full report in `02-PLAN-CHECK.md`.

## Wave structure

| Wave | Plans | Notes |
|------|-------|-------|
| 1 | 02-01, 02-02 | Independent, parallelizable |
| 2 | 02-03 | Depends on 02-02 |
| 3 | 02-04 | Depends on 02-01, 02-02, 02-03 |

## Notable research finding

ROADMAP SC2 "byte-equal golden test" is **impossible** — presigned STS URL contains per-call X-Amz-Date and HMAC signature. Plan 02-01 replaces it with a **structural-equivalence** test (k8s-aws-v1 prefix, base64url no-padding, valid presigned URL, x-k8s-aws-id in signed headers). Documented as deviation.

## Zero new dependencies

boto3 1.43, moto[eks,sts] 5.2, boto3-stubs[eks,sts] all already pinned from Phase 1's pyproject.toml.

## Forward compatibility

- `AuthStrategy` is `@runtime_checkable Protocol` — Phase 4 `OidcWebIdentityStrategy` just implements it
- `select_strategy` has comment placeholder for OIDC branch
- `Settings.aws_session_token` will be added (research caught its absence)
- Closes Phase 1 OBS-01 PARTIAL gap via `structlog.info("auth strategy selected", auth_strategy=...)`

## Test plan

- [ ] CI green
- [ ] Yves reviews plans
- [ ] After merge: `/gsd-execute-phase 2` on a fresh branch from main
