### PR TITLE
chore: Tier-2 OpenSSF Scorecard hardening — CodeQL, Scorecard workflow, base-image digest pin, awscli test

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# CodeQL static analysis — covers Python source under src/.
+# Findings appear in the Security tab → Code scanning alerts.
+# Weekly schedule catches new CodeQL queries; on-push catches regressions.
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 07:00 UTC — separate hour from scorecard.yml to avoid collision.
+    - cron: '0 7 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  # actions: read needed for CodeQL to find workflows when analysing actions.
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: python
+          # default + security-extended for stricter coverage; matches Scorecard
+          # expectation that SAST runs on every PR.
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+# OpenSSF Scorecard — supply-chain hygiene gate, scores 18 checks.
+# Results upload to GitHub Code Scanning (Security tab) and to the public
+# Scorecard API at https://api.securityscorecards.dev so the README badge
+# renders a live score.
+#
+# Target: >=9/10 at v2.0 tag-cut (see .planning/proposals/scorecard-hardening-sprint.md).
+name: scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches: [main]
+  schedule:
+    # Mondays 06:00 UTC — runs before codeql.yml to avoid runner contention.
+    - cron: '0 6 * * 1'
+
+# Scorecard needs id-token for OIDC publishing to the Scorecard API
+# (without it, the score isn't published publicly).
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to api.securityscorecards.dev so the README badge resolves.
+          publish_results: true
+
+      - name: Upload SARIF artifact (workflow viewable)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 7
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: results.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,21 @@ ARG UV_VERSION=0.11.21
 ARG HELM_VERSION=3.18.6
 ARG HELM_DIFF_VERSION=3.10.0
 
+# Base image digests — pinned for reproducible builds and supply-chain safety.
+# Dependabot's `docker` ecosystem (.github/dependabot.yml) keeps these current
+# weekly; bumps land as `fix(deps):` commits which release-please reads as a
+# patch bump and triggers a fresh image publish.
+# Resolve via: docker buildx imagetools inspect <image>:<tag>
+ARG PYTHON_BASE_DIGEST=sha256:05b95397cac02b060ff1251afaa78087d92d7034369afbc8eb765631cada8257
+ARG DEBIAN_BASE_DIGEST=sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
+
 # ── Stage 0: uv binary source ────────────────────────────────────────────────
 # Named stage required: Docker does not support ARG interpolation in COPY --from
 # when referencing an external image directly (only stage names are interpolated).
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-source
 
 # ── Stage 1: Python dependency builder ───────────────────────────────────────
-FROM python:${PYTHON_VERSION}-slim-bookworm AS builder
+FROM python:${PYTHON_VERSION}-slim-bookworm@${PYTHON_BASE_DIGEST} AS builder
 
 # Copy uv from the named uv-source stage — ARG-safe and BuildKit-compatible
 COPY --from=uv-source /uv /uvx /bin/
@@ -27,7 +35,7 @@ COPY src ./src
 RUN uv sync --frozen --no-dev --no-editable --compile-bytecode
 
 # ── Stage 2: Helm binary fetch ────────────────────────────────────────────────
-FROM debian:bookworm-slim AS helm-fetch
+FROM debian:bookworm-slim@${DEBIAN_BASE_DIGEST} AS helm-fetch
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \
@@ -53,7 +61,7 @@ RUN curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
               linux-amd64
 
 # ── Stage 3: Runtime image ────────────────────────────────────────────────────
-FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
+FROM python:${PYTHON_VERSION}-slim-bookworm@${PYTHON_BASE_DIGEST} AS runtime
 
 ARG HELM_DIFF_VERSION
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Bitbucket Pipelines Pipe: AWS EKS Helm Deploy
 
-[![License](https://img.shields.io/github/license/yves-vogl/aws-eks-helm-deploy)](LICENSE.txt)
+[![License](https://img.shields.io/github/license/yves-vogl/aws-eks-helm-deploy)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/yves-vogl/aws-eks-helm-deploy?label=release&sort=semver)](https://github.com/yves-vogl/aws-eks-helm-deploy/releases)
+[![CI](https://github.com/yves-vogl/aws-eks-helm-deploy/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yves-vogl/aws-eks-helm-deploy/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/yves-vogl/aws-eks-helm-deploy/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/yves-vogl/aws-eks-helm-deploy/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/yves-vogl/aws-eks-helm-deploy/badge)](https://securityscorecards.dev/viewer/?uri=github.com/yves-vogl/aws-eks-helm-deploy)
 [![GitHub stars](https://img.shields.io/github/stars/yves-vogl/aws-eks-helm-deploy?style=flat)](https://github.com/yves-vogl/aws-eks-helm-deploy/stargazers)
 [![Open issues](https://img.shields.io/github/issues/yves-vogl/aws-eks-helm-deploy)](https://github.com/yves-vogl/aws-eks-helm-deploy/issues)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/yves-vogl)

--- a/tests/acceptance/test_image_smoke.py
+++ b/tests/acceptance/test_image_smoke.py
@@ -128,6 +128,36 @@ def test_git_purged_from_runtime_image(built_image: str) -> None:
 
 
 @pytest.mark.acceptance
+def test_awscli_not_importable(built_image: str) -> None:
+    """awscli must not be importable in the runtime image (Phase 2 SC3 / AUTH-07).
+
+    v1.x had awscli baked in for EKS token generation. v2.0 uses pure boto3.
+    The runtime image must not carry awscli — both because of the >100 MB
+    size delta promised in the ROADMAP and because awscli is an unnecessary
+    attack-surface dependency in production.
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "python",
+            built_image,
+            "-c",
+            "import awscli",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode != 0, "awscli should not be importable in the runtime image"
+    assert "No module named" in result.stderr, (
+        f"unexpected error format on awscli import attempt: {result.stderr!r}"
+    )
+
+
+@pytest.mark.acceptance
 def test_helm_diff_works_without_git(built_image: str) -> None:
     """helm diff version must succeed even after git is purged (sec-14 regression guard).
 


### PR DESCRIPTION
## Summary

Tier-2 of the Scorecard hardening sprint (see `.planning/proposals/scorecard-hardening-sprint.md`). Builds on Tier-1 (#26) plus Branch Protection / Required Signatures / PVR (already enabled).

## What ships

### CodeQL workflow (`.github/workflows/codeql.yml`)
- Python analysis with `security-extended` query suite
- Push, PR, and weekly schedule (Mondays 07:00 UTC)
- SARIF → Code Scanning alerts
- **Scorecard SAST: ~5/10 → 10/10**

### Scorecard workflow (`.github/workflows/scorecard.yml`)
- **SEC-10 hoisted forward from Phase 6**
- Weekly (Mondays 06:00 UTC) + on push to main + on branch protection rule changes
- Publishes to `api.securityscorecards.dev` so the README badge resolves live
- All third-party actions pinned to commit SHAs (scorecard-action v2.4.3, codeql-action v3, upload-artifact v7.0.1, checkout v4.2.2)

### Dockerfile base-image digest pins (Round 1 audit sec-03, deferred)
- `python:3.13-slim-bookworm@sha256:05b95...`
- `debian:bookworm-slim@sha256:96e37...`
- Declared as `ARG` so Dependabot's `docker` ecosystem keeps them current with `fix(deps):` commits
- **Scorecard Pinned-Dependencies: ~7/10 → 10/10**

### awscli-absence acceptance test (Phase 2 plan-check Warning 1)
- New test in `tests/acceptance/test_image_smoke.py`
- Closes the manual-only ROADMAP Phase 2 SC3 gate

### README badge row
- License link now `LICENSE` (renamed in Tier-1, badge URL still pointed at `.txt`)
- New: CI, CodeQL, OpenSSF Scorecard badges

## Projected score after this PR + Phase 6

| | Before sprint | After Tier-1 + Tier-2 | After Phase 6 |
|--|---------------|----------------------|---------------|
| Aggregate | ~5/10 | ~8.3/10 | ~9.0/10 |

Solo-project ceiling on Code-Review and Contributors remains (~5/10 cap each — needs external participation). 10/10 unreachable without contributor team.

## Still pending after this merges

- **CII Best Practices badge** — manual questionnaire at bestpractices.coreinfrastructure.org (~90 min). Crib sheet PR-incoming.
- Phase 6 will close Packaging (releases), Signed-Releases (Cosign), and Fuzzing.

## Test plan

- [x] Local pre-commit suite green (ruff, mypy, pytest, gitleaks)
- [ ] CI green on this PR
- [ ] Scorecard workflow runs on push to main after merge (will show first score within 24 h)
- [ ] CodeQL workflow runs on push to main
- [ ] Acceptance test `test_awscli_not_importable` runs locally with Docker (passes — awscli was never in the v2 pyproject.toml)