### PR TITLE
chore: ruff format + E501 fix on Phase 6 helper scripts

### DIFF
--- a/scripts/_trivyignore_parser.py
+++ b/scripts/_trivyignore_parser.py
@@ -37,9 +37,7 @@ def _check_expiry(i: int, cve: str, expires_str: str, today: date) -> list[str]:
         errors.append(f"Line {i}: malformed expires= field: {expires_str!r}")
         return errors
     if expires < today:
-        errors.append(
-            f"Line {i}: {cve} expiry {expires.isoformat()} is PAST — remove or extend"
-        )
+        errors.append(f"Line {i}: {cve} expiry {expires.isoformat()} is PAST — remove or extend")
     elif (expires - today).days > MAX_DAYS:
         errors.append(
             f"Line {i}: {cve} expiry {expires.isoformat()} is > {MAX_DAYS} days — shorten"
@@ -96,7 +94,10 @@ def emit_bare(path: pathlib.Path, out: pathlib.Path) -> None:
 def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else argv
     if not args:
-        print("usage: trivyignore-check.sh <path-to-trivyignore> [--emit-bare <out>]", file=sys.stderr)
+        print(
+            "usage: trivyignore-check.sh <path-to-trivyignore> [--emit-bare <out>]",
+            file=sys.stderr,
+        )
         return 2
     path = pathlib.Path(args[0])
     errors = check(path)

--- a/scripts/rescan-issue-creator.py
+++ b/scripts/rescan-issue-creator.py
@@ -71,8 +71,7 @@ def _parse_sarif(path: pathlib.Path) -> list[dict[str, str]]:
     findings: list[dict[str, str]] = []
     for run in sarif.get("runs", []):
         rules = {
-            rule["id"]: rule
-            for rule in run.get("tool", {}).get("driver", {}).get("rules", [])
+            rule["id"]: rule for rule in run.get("tool", {}).get("driver", {}).get("rules", [])
         }
         for result in run.get("results", []):
             rule_id = result.get("ruleId", "")

--- a/scripts/scorecard-exception-check.py
+++ b/scripts/scorecard-exception-check.py
@@ -28,17 +28,14 @@ def _parse_frontmatter(text: str) -> dict[str, Any]:
     return data
 
 
-def _check_review_date(
-    i: int, entry: dict[str, Any], today: date
-) -> list[str]:
+def _check_review_date(i: int, entry: dict[str, Any], today: date) -> list[str]:
     """Validate review_date for a single exception entry. Returns error list."""
     errors: list[str] = []
     raw_date = entry["review_date"]
     review = raw_date if isinstance(raw_date, date) else date.fromisoformat(str(raw_date))
     if review < today:
         errors.append(
-            f"Entry {i} ({entry.get('check', '?')}): review_date"
-            f" {review.isoformat()} is PAST"
+            f"Entry {i} ({entry.get('check', '?')}): review_date {review.isoformat()} is PAST"
         )
     elif (review - today).days > MAX_DAYS:
         errors.append(


### PR DESCRIPTION
## Summary

Pre-existing ruff format drift and one E501 violation on three Phase-6-era helper scripts (`scripts/_trivyignore_parser.py`, `scripts/rescan-issue-creator.py`, `scripts/scorecard-exception-check.py`). Flagged during Phase 7 execution as deferred-items; cleanup PR.

- `_trivyignore_parser.py:99` — usage string was 103 chars (limit 100). Split across 3 lines.
- All 3 files reformatted via `uv run ruff format`.

## Test plan

- [x] `uv run ruff check scripts/` clean
- [x] `uv run ruff format --check scripts/` clean
- [x] Pre-commit pytest green