### PR TITLE
docs(admin): restore Phase 6 sections in repo-settings.md (Project Board + Labels + Sanity-Check)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -62,9 +62,9 @@
 
 - [ ] `git tag v2.0.0 && git push --tags` — triggers `.github/workflows/release.yml`.
 - [ ] Monitor release.yml run; verify Cosign signature + SBOM attestations attached.
-- [ ] After the v2 docs site is live: enable GitHub Pages per [`docs/admin/repo-settings.md` §5](../blob/main/docs/admin/repo-settings.md#5-enable-github-pages-doc-02).
-- [ ] After the first `mike deploy v2 latest` workflow run succeeds: run [`mike set-default v2 --push`](../blob/main/docs/admin/repo-settings.md#6-set-default-mike-alias-to-v2-doc-02-sc-3).
-- [ ] Deploy the frozen v1 docs snapshot per [`docs/admin/repo-settings.md` §7](../blob/main/docs/admin/repo-settings.md#7-deploy-frozen-v1-docs-snapshot-d2--plan-07-01).
-- [ ] Update the Bitbucket Pipe Marketplace listing per [`docs/admin/repo-settings.md` §8](../blob/main/docs/admin/repo-settings.md#8-update-bitbucket-pipe-marketplace-listing-d11).
-- [ ] Post the Docker Hub README deprecation banner per [`docs/admin/repo-settings.md` §9](../blob/main/docs/admin/repo-settings.md#9-post-docker-hub-readme-deprecation-banner-mig-01).
-- [ ] Compute the absolute end-of-support date for v1.x (= v2.0.0 release date + 6 months) and open a follow-up PR replacing the literal `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` placeholder in `SECURITY.md`, `docs/migration/v1-to-v2.md`, AND `docs/admin/repo-settings.md` sections 7 + 9 (SI-07-07 invariant gate enforces).
+- [ ] After the v2 docs site is live: enable GitHub Pages per [`docs/admin/repo-settings.md` §7](../blob/main/docs/admin/repo-settings.md#7-enable-github-pages-doc-02).
+- [ ] After the first `mike deploy v2 latest` workflow run succeeds: run [`mike set-default v2 --push`](../blob/main/docs/admin/repo-settings.md#8-set-default-mike-alias-to-v2-doc-02-sc-3).
+- [ ] Deploy the frozen v1 docs snapshot per [`docs/admin/repo-settings.md` §9](../blob/main/docs/admin/repo-settings.md#9-deploy-frozen-v1-docs-snapshot-d2--plan-07-01).
+- [ ] Update the Bitbucket Pipe Marketplace listing per [`docs/admin/repo-settings.md` §10](../blob/main/docs/admin/repo-settings.md#10-update-bitbucket-pipe-marketplace-listing-d11).
+- [ ] Post the Docker Hub README deprecation banner per [`docs/admin/repo-settings.md` §11](../blob/main/docs/admin/repo-settings.md#11-post-docker-hub-readme-deprecation-banner-mig-01).
+- [ ] Compute the absolute end-of-support date for v1.x (= v2.0.0 release date + 6 months) and open a follow-up PR replacing the literal `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` placeholder in `SECURITY.md`, `docs/migration/v1-to-v2.md`, AND `docs/admin/repo-settings.md` sections 9 + 11 (SI-07-07 invariant gate enforces).

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -39,11 +39,11 @@ The branch is ready. **Yves runs these steps; Claude will NOT run them autonomou
 
 1. `git checkout main && git pull && git tag v2.0.0 && git push --tags`
 2. Verify `release.yml` ran: `gh run list --workflow=release.yml --limit 5`
-3. Enable GitHub Pages — see `docs/admin/repo-settings.md` §5.
-4. Set default mike alias — `docs/admin/repo-settings.md` §6.
-5. Publish v1 frozen snapshot — `docs/admin/repo-settings.md` §7.
-6. Update Bitbucket Pipe Marketplace listing — `docs/admin/repo-settings.md` §8.
-7. Paste Docker Hub README deprecation banner — `docs/admin/repo-settings.md` §9.
+3. Enable GitHub Pages — see `docs/admin/repo-settings.md` §7.
+4. Set default mike alias — `docs/admin/repo-settings.md` §8.
+5. Publish v1 frozen snapshot — `docs/admin/repo-settings.md` §9.
+6. Update Bitbucket Pipe Marketplace listing — `docs/admin/repo-settings.md` §10.
+7. Paste Docker Hub README deprecation banner — `docs/admin/repo-settings.md` §11.
 8. Replace `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` placeholder in SECURITY.md + `docs/migration/v1-to-v2.md` with the absolute date (commit as `chore(security): freeze v1.x EOS date`).
 
 PR #45 body has the same checklist; PR template carries it forward for future use.

--- a/docs/admin/repo-settings.md
+++ b/docs/admin/repo-settings.md
@@ -154,7 +154,77 @@ gh api repos/yves-vogl/aws-eks-helm-deploy --jq .allow_auto_merge
 
 ---
 
-## 5. Enable GitHub Pages (DOC-02)
+## 5. Create the v2.0 GitHub Project Board (CMN-03)
+
+GitHub Projects v2 board creation with column configuration is web-UI only as of
+2026-06. There is no `gh project create` subcommand that fully configures columns.
+
+**Web UI navigation:**
+
+1. Go to `https://github.com/users/yves-vogl/projects/new`.
+2. Click "New project" → select the **Board** template.
+3. Name: **`aws-eks-helm-deploy v2.0`**.
+4. Description: "v2.0 milestone tracker."
+5. Configure columns (in order): `Backlog → Ready → In Progress → In Review → Done`.
+6. Link the project to the repo: from project Settings → "Manage access" → add
+   `yves-vogl/aws-eks-helm-deploy` as a linked repository.
+7. Add auto-add filter: configure the project to auto-add issues + PRs labeled
+   `milestone:v2.0.0`.
+
+**Verify:** The project appears at `https://github.com/users/yves-vogl/projects/<N>`
+with all 5 columns and the auto-add filter active.
+
+---
+
+## 6. Create the Label Taxonomy (CMN-04)
+
+The label taxonomy covers `area/*`, `type/*`, `priority/*`, plus a handful of
+common labels (`breaking-change`, `good first issue`, `help wanted`,
+`dependencies`, `python`, `docker`, `ci`).
+
+**Command (one-shot — idempotent because `|| true` swallows the
+"already exists" error from `gh`):**
+
+```bash
+REPO=yves-vogl/aws-eks-helm-deploy
+
+# area/* labels (blue family)
+for label in \
+    "area/auth" "area/chart" "area/ci" "area/docs" \
+    "area/helm" "area/oidc" "area/security" "area/triage"; do
+  gh label create "$label" --color "0075ca" --repo "$REPO" 2>/dev/null || true
+done
+
+# type/* labels (orange-red family)
+for label in "type/bug" "type/feature" "type/chore" "type/docs" "type/security"; do
+  gh label create "$label" --color "d93f0b" --repo "$REPO" 2>/dev/null || true
+done
+
+# priority/* labels (yellow family)
+for label in "priority/p0" "priority/p1" "priority/p2" "priority/p3"; do
+  gh label create "$label" --color "e4e669" --repo "$REPO" 2>/dev/null || true
+done
+
+# Stand-alone labels
+gh label create "breaking-change"  --color "b60205" --repo "$REPO" 2>/dev/null || true
+gh label create "good first issue" --color "7057ff" --repo "$REPO" 2>/dev/null || true
+gh label create "help wanted"      --color "008672" --repo "$REPO" 2>/dev/null || true
+gh label create "dependencies"     --color "0366d6" --repo "$REPO" 2>/dev/null || true
+gh label create "python"           --color "2b67c6" --repo "$REPO" 2>/dev/null || true
+gh label create "docker"           --color "0db7ed" --repo "$REPO" 2>/dev/null || true
+gh label create "ci"               --color "f9d0c4" --repo "$REPO" 2>/dev/null || true
+```
+
+**Verify:**
+
+```bash
+gh label list --repo $REPO --json name --jq 'length'
+# Expected: at least 20 (8 area + 5 type + 4 priority + 7 standalone)
+```
+
+---
+
+## 7. Enable GitHub Pages (DOC-02)
 
 The `.github/workflows/docs.yml` workflow (Plan 07-05) requires GitHub Pages to
 be enabled with `gh-pages` as the source branch BEFORE the first `mike deploy`
@@ -191,7 +261,7 @@ gh api repos/yves-vogl/aws-eks-helm-deploy/pages \
 
 ---
 
-## 6. Set default mike alias to v2 (DOC-02 SC-3)
+## 8. Set default mike alias to v2 (DOC-02 SC-3)
 
 `.github/workflows/docs.yml` deploys `v2 + latest` aliases on every `main`
 commit. Setting the default alias writes `index.html` at the gh-pages root
@@ -224,7 +294,7 @@ misconfigured.
 
 ---
 
-## 7. Deploy frozen v1 docs snapshot (D2 — Plan 07-01)
+## 9. Deploy frozen v1 docs snapshot (D2 — Plan 07-01)
 
 The mike layout in CONTEXT D2 reserves `/v1/` for a single-page frozen v1.3.0
 reference. This deploy is a one-shot maintainer command (NEVER from CI —
@@ -258,7 +328,7 @@ curl -sf https://yves-vogl.github.io/aws-eks-helm-deploy/v1/ | head -5
 
 ---
 
-## 8. Update Bitbucket Pipe Marketplace listing (D11)
+## 10. Update Bitbucket Pipe Marketplace listing (D11)
 
 After the v2.0.0 tag-cut, update the Bitbucket Pipe Marketplace listing to
 reflect the new image registry, version, and capabilities (OIDC, OCI charts,
@@ -279,7 +349,7 @@ This is **not idempotent via web UI** — verify visually after submitting.
 
 ---
 
-## 9. Post Docker Hub README deprecation banner (MIG-01)
+## 11. Post Docker Hub README deprecation banner (MIG-01)
 
 The Docker Hub `yvogl/aws-eks-helm-deploy` repository is frozen at v1.3.0
 (MIG-01). Post a deprecation banner to its README so consumers searching
@@ -309,17 +379,57 @@ above the existing content):
 Web-UI only step; no API. **Not idempotent via API.** Confirm visually after
 submitting.
 
+## 12. Sanity-Check Post-Actions
+
+After completing steps 1–7, run this one-liner to confirm everything is wired:
+
+```bash
+REPO=yves-vogl/aws-eks-helm-deploy
+
+echo "=== Repo settings ==="
+gh api repos/$REPO --jq '{visibility, default_branch, allow_auto_merge}'
+
+echo "=== Private Vulnerability Reporting ==="
+gh api repos/$REPO/private-vulnerability-reporting --jq '{enabled}'
+
+echo "=== Branch protection ==="
+gh api repos/$REPO/branches/main/protection --jq '{
+  enforce_admins:     .enforce_admins.enabled,
+  required_reviews:   .required_pull_request_reviews.required_approving_review_count,
+  status_check_count: (.required_status_checks.contexts | length),
+  contexts:           .required_status_checks.contexts
+}'
+
+echo "=== Required signatures ==="
+gh api repos/$REPO/branches/main/protection/required_signatures --jq '.enabled'
+
+echo "=== Label count ==="
+gh label list --repo $REPO --json name --jq 'length'
+```
+
+**Expected results:**
+- `allow_auto_merge: true`
+- Private Vulnerability Reporting `enabled: true`
+- `enforce_admins: true`, `required_reviews: 1`, `status_check_count: 8`
+- Required signatures `true`
+- Label count `>= 20`
+
 ---
 
-## Notes (Phase 7 — sections 5-9)
+## Notes
 
-- Sections 5–7 (Pages, mike set-default, mike deploy v1) are `gh api` + `mike`
-  commands and are idempotent for sections 5 and 6 (Section 7 is a one-shot
+- **Section grouping:** §§1-4 are Phase 6 commit-time settings (PVR + branch
+  protection + GPG + auto-merge). §§5-6 are Phase 6 web-UI / one-shot CLI
+  steps (Project Board + Labels). §§7-11 are Phase 7 v2.0.0 release-ceremony
+  steps (Pages enablement + mike one-shots + Marketplace + Docker Hub banner).
+  §12 is the post-actions sanity-check covering all 11 prior sections.
+- Sections 7–9 (Pages, mike set-default, mike deploy v1) are `gh api` + `mike`
+  commands and are idempotent for sections 7 and 8 (Section 9 is a one-shot
   intent — re-running is harmless but unnecessary).
-- Sections 8–9 (Bitbucket Pipe Marketplace + Docker Hub banner) are web-UI
+- Sections 10–11 (Bitbucket Pipe Marketplace + Docker Hub banner) are web-UI
   only with no programmatic idempotency guarantee; confirm visually.
-- The literal placeholder `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` is the SI-07-07 invariant; it appears in three places in v2.0:
-  `SECURITY.md` (Plan 07-06), `docs/migration/v1-to-v2.md` (Plan 07-04), AND
-  `docs/admin/repo-settings.md` Section 7 + 9 (this plan). After the v2.0.0
-  tag-cut, the maintainer replaces all four occurrences in a single follow-up
-  PR.
+- The literal placeholder `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.`
+  is the SI-07-07 invariant; it appears in v2.0 in `SECURITY.md` (Plan 07-06),
+  `docs/migration/v1-to-v2.md` (Plan 07-04), AND `docs/admin/repo-settings.md`
+  Section 9 + 11 (this plan). After the v2.0.0 tag-cut, the maintainer
+  replaces all occurrences in a single follow-up PR.

--- a/tests/structural/test_repo_settings_runbook.py
+++ b/tests/structural/test_repo_settings_runbook.py
@@ -1,17 +1,17 @@
 """Structural tests for Phase 7 / Plan 07-07.
 
-Asserts docs/admin/repo-settings.md ships the 5 new sections (5-9) for the
-v2.0.0 release ceremony per D11:
+Asserts docs/admin/repo-settings.md ships the 5 new sections (7-11) for the
+v2.0.0 release ceremony per D11 (Phase 6 §§5-6 + §12 restored alongside):
 
-- Section 5: Enable GitHub Pages (RESEARCH Q6).
-- Section 6: Set default mike alias to v2 (RESEARCH Q10 pitfall #5).
-- Section 7: Deploy frozen v1 docs snapshot (RESEARCH Q10 pitfall #6).
-- Section 8: Update Bitbucket Pipe Marketplace listing (D11).
-- Section 9: Post Docker Hub README deprecation banner (MIG-01 / D10).
+- Section 7: Enable GitHub Pages (RESEARCH Q6).
+- Section 8: Set default mike alias to v2 (RESEARCH Q10 pitfall #5).
+- Section 9: Deploy frozen v1 docs snapshot (RESEARCH Q10 pitfall #6).
+- Section 10: Update Bitbucket Pipe Marketplace listing (D11).
+- Section 11: Post Docker Hub README deprecation banner (MIG-01 / D10).
 
 Also asserts the SI-07-07 invariant: the D10 placeholder
 '2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.' appears
-at least twice in the runbook (sections 7 + 9).
+at least twice in the runbook (sections 9 + 11).
 """
 
 from __future__ import annotations
@@ -32,84 +32,93 @@ def test_runbook_exists() -> None:
 
 
 def test_runbook_has_pages_enablement_section() -> None:
-    """Section 5 — Enable GitHub Pages (DOC-02)."""
-    assert "## 5. Enable GitHub Pages" in RUNBOOK.read_text(), (
-        "Section 5 (Enable GitHub Pages) must be present in the runbook"
+    """Section 7 — Enable GitHub Pages (DOC-02)."""
+    assert "## 7. Enable GitHub Pages" in RUNBOOK.read_text(), (
+        "Section 7 (Enable GitHub Pages) must be present in the runbook"
     )
 
 
-def test_runbook_section_5_uses_gh_api_pages_endpoint() -> None:
-    """Section 5 must use the RESEARCH Q6 verbatim gh api endpoint."""
+def test_runbook_section_7_uses_gh_api_pages_endpoint() -> None:
+    """Section 7 must use the RESEARCH Q6 verbatim gh api endpoint."""
     assert "gh api repos/yves-vogl/aws-eks-helm-deploy/pages" in RUNBOOK.read_text(), (
-        "Section 5 must invoke the gh api pages endpoint per RESEARCH Q6"
+        "Section 7 must invoke the gh api pages endpoint per RESEARCH Q6"
     )
 
 
 def test_runbook_has_mike_set_default_section() -> None:
-    """Section 6 — Set default mike alias to v2 (DOC-02 SC-3)."""
-    assert "## 6. Set default mike alias to v2" in RUNBOOK.read_text(), (
-        "Section 6 (Set default mike alias to v2) must be present"
+    """Section 8 — Set default mike alias to v2 (DOC-02 SC-3)."""
+    assert "## 8. Set default mike alias to v2" in RUNBOOK.read_text(), (
+        "Section 8 (Set default mike alias to v2) must be present"
     )
 
 
-def test_runbook_section_6_uses_mike_set_default_push() -> None:
-    """Section 6 must use the `mike set-default v2 --push` one-shot."""
+def test_runbook_section_8_uses_mike_set_default_push() -> None:
+    """Section 8 must use the `mike set-default v2 --push` one-shot."""
     assert "mike set-default v2 --push" in RUNBOOK.read_text(), (
-        "Section 6 must invoke `mike set-default v2 --push` per RESEARCH Q10 pitfall #5"
+        "Section 8 must invoke `mike set-default v2 --push` per RESEARCH Q10 pitfall #5"
     )
 
 
 def test_runbook_has_mike_v1_deploy_section() -> None:
-    """Section 7 — Deploy frozen v1 docs snapshot (D2 — Plan 07-01)."""
-    assert "## 7. Deploy frozen v1 docs snapshot" in RUNBOOK.read_text(), (
-        "Section 7 (Deploy frozen v1 docs snapshot) must be present"
+    """Section 9 — Deploy frozen v1 docs snapshot (D2 — Plan 07-01)."""
+    assert "## 9. Deploy frozen v1 docs snapshot" in RUNBOOK.read_text(), (
+        "Section 9 (Deploy frozen v1 docs snapshot) must be present"
     )
 
 
-def test_runbook_section_7_uses_mike_deploy_push_v1() -> None:
-    """Section 7 must invoke `mike deploy --push v1` and note CI-exclusion."""
+def test_runbook_section_9_uses_mike_deploy_push_v1() -> None:
+    """Section 9 must invoke `mike deploy --push v1` and note CI-exclusion."""
     text = RUNBOOK.read_text()
     assert "mike deploy --push v1" in text, (
-        "Section 7 must invoke `mike deploy --push v1` per RESEARCH Q10 pitfall #6"
+        "Section 9 must invoke `mike deploy --push v1` per RESEARCH Q10 pitfall #6"
     )
     assert "CI never touches it" in text or "NEVER from CI" in text, (
-        "Section 7 must explicitly note this command MUST NOT run from CI (Q10 pitfall #6)"
+        "Section 9 must explicitly note this command MUST NOT run from CI (Q10 pitfall #6)"
     )
 
 
 def test_runbook_has_marketplace_section() -> None:
-    """Section 8 — Update Bitbucket Pipe Marketplace listing (D11)."""
-    assert "## 8. Update Bitbucket Pipe Marketplace listing" in RUNBOOK.read_text(), (
-        "Section 8 (Bitbucket Pipe Marketplace listing update) must be present"
+    """Section 10 — Update Bitbucket Pipe Marketplace listing (D11)."""
+    assert "## 10. Update Bitbucket Pipe Marketplace listing" in RUNBOOK.read_text(), (
+        "Section 10 (Bitbucket Pipe Marketplace listing update) must be present"
     )
 
 
 def test_runbook_has_docker_hub_banner_section() -> None:
-    """Section 9 — Post Docker Hub README deprecation banner (MIG-01)."""
-    assert "## 9. Post Docker Hub README deprecation banner" in RUNBOOK.read_text(), (
-        "Section 9 (Docker Hub README deprecation banner) must be present"
+    """Section 11 — Post Docker Hub README deprecation banner (MIG-01)."""
+    assert "## 11. Post Docker Hub README deprecation banner" in RUNBOOK.read_text(), (
+        "Section 11 (Docker Hub README deprecation banner) must be present"
     )
 
 
 def test_runbook_propagates_d10_placeholder() -> None:
-    """SI-07-07: the D10 6-month placeholder must appear ≥ 2 times (Sections 7 + 9)."""
+    """SI-07-07: the D10 6-month placeholder must appear ≥ 2 times (Sections 9 + 11)."""
     text = RUNBOOK.read_text()
     count = text.count(D10_PLACEHOLDER)
     assert count >= 2, (
         f"SI-07-07 invariant broken: D10 placeholder appears {count} time(s), "
-        f"expected ≥ 2 (Section 7 v1 banner + Section 9 Docker Hub banner)"
+        f"expected ≥ 2 (Section 9 v1 banner + Section 11 Docker Hub banner)"
     )
 
 
-def test_runbook_sections_1_to_4_remain_present() -> None:
-    """Append-only invariant — sections 1-4 from Phase 6 must remain in the file."""
+def test_runbook_sections_1_to_6_remain_present() -> None:
+    """Append-only invariant — Phase 6 §§1-4 + restored §§5-6 must remain in the file."""
     text = RUNBOOK.read_text()
     for heading in [
         "## 1. Enable GitHub Private Vulnerability Reporting",
         "## 2. Configure Branch Protection on `main`",
         "## 3. Require GPG-Signed Commits",
         '## 4. Enable "Allow auto-merge" Repo Setting',
+        "## 5. Create the v2.0 GitHub Project Board",
+        "## 6. Create the Label Taxonomy",
     ]:
         assert heading in text, (
             f"Append-only invariant broken — section heading missing: {heading!r}"
         )
+
+
+def test_runbook_has_sanity_check_section() -> None:
+    """Section 12 — Sanity-Check Post-Actions (Phase 6 restored)."""
+    assert "## 12. Sanity-Check Post-Actions" in RUNBOOK.read_text(), (
+        "Section 12 (Sanity-Check Post-Actions, restored from Phase 6) must be present"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -139,7 +139,7 @@ dev = [
     { name = "moto", extras = ["eks", "sts"], specifier = "~=5.2" },
     { name = "mypy", specifier = "~=2.1" },
     { name = "pip-audit", specifier = "~=2.10" },
-    { name = "pre-commit", specifier = "~=4.0" },
+    { name = "pre-commit", specifier = "~=4.6" },
     { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.1" },
     { name = "pytest-mock", specifier = "~=3.15" },


### PR DESCRIPTION
## Summary

Plan 07-07 executor accidentally replaced Phase 6's sections §§5-8 of `docs/admin/repo-settings.md` (Project Board CMN-03, Label Taxonomy CMN-04, Docker Hub README, Sanity-Check) with Phase 7's §§5-9 (Pages, mike, Marketplace, Hub banner) during execution. This was flagged as a known deviation in Phase 7's verification.

This PR restores the three structural Phase 6 sections and renumbers Phase 7's sections accordingly. Phase 6 §7 (Docker Hub README Update) is intentionally NOT restored because Phase 7 §11 (renumbered) supersedes it with a better banner template + the SI-07-07 placeholder.

### New numbering

| § | Section | Source |
|---|---|---|
| 1 | Enable GitHub Private Vulnerability Reporting (SEC-09) | Phase 6 |
| 2 | Configure Branch Protection on `main` (CI-07) | Phase 6 |
| 3 | Require GPG-Signed Commits (CI-06) | Phase 6 |
| 4 | Enable "Allow auto-merge" Repo Setting (CI-05) | Phase 6 |
| 5 | Create the v2.0 GitHub Project Board (CMN-03) | **Phase 6 RESTORED** |
| 6 | Create the Label Taxonomy (CMN-04) | **Phase 6 RESTORED** |
| 7 | Enable GitHub Pages (DOC-02) | Phase 7 (was §5) |
| 8 | Set default mike alias to v2 (DOC-02 SC-3) | Phase 7 (was §6) |
| 9 | Deploy frozen v1 docs snapshot (D2 / Plan 07-01) | Phase 7 (was §7) |
| 10 | Update Bitbucket Pipe Marketplace listing (D11) | Phase 7 (was §8) |
| 11 | Post Docker Hub README deprecation banner (MIG-01) | Phase 7 (was §9) |
| 12 | Sanity-Check Post-Actions | **Phase 6 RESTORED** |

### Reference updates

- `.github/PULL_REQUEST_TEMPLATE.md`: 5 maintainer-checklist anchors updated to new section numbers.
- `.planning/STATE.md`: 5 ceremony-checklist references updated.
- `tests/structural/test_repo_settings_runbook.py`: section heading assertions + helper function names updated; added `test_runbook_has_sanity_check_section` for the restored §12.
- `uv.lock`: synced after PR #42 (pre-commit ~=4.6 bump) merged on main.

## Test plan

- [x] `uv run pytest tests/structural/test_repo_settings_runbook.py tests/structural/test_governance_files.py -q --no-cov` → 44 passed
- [x] `uv run --extra docs mkdocs build --strict` exits 0
- [x] Pre-commit hook (pytest, no-cov) green
- [ ] CI green on this PR