### PR TITLE
docs(07): mark Phase 7 deferred-items resolved + carry Phase 6 follow-ups

### DIFF
--- a/.planning/phases/07-documentation-site-migration-guide/deferred-items.md
+++ b/.planning/phases/07-documentation-site-migration-guide/deferred-items.md
@@ -1,10 +1,26 @@
 # Phase 7 — Deferred Items (out-of-scope findings)
 
+All items below were flagged during Phase 7 plan execution as out-of-scope.
+Status as of 2026-06-23.
+
 ## From Plan 07-01 execution
 
-- **Pre-existing ruff E501 in `scripts/_trivyignore_parser.py:99`** — line 103 chars (limit 100). Inherited from Phase 6 (commit cca2868). Out of scope for Plan 07-01 (whitelist: pyproject.toml + mkdocs.yml + docs/ + tests/structural/ only). Suggested fix: split the usage string. Track for a future cleanup PR — does NOT affect any Phase 7 plan.
+- ~~**Pre-existing ruff E501 in `scripts/_trivyignore_parser.py:99`** — line 103 chars (limit 100).~~
+  → **RESOLVED** in PR #47 (commit 084207c) — usage string split across 3 lines.
 
 ## From Plan 07-03 execution
 
-- **`site/` (mkdocs build output) not in `.gitignore`** — `uv run --extra docs mkdocs build --strict` produces `site/` at repo root. Plan 07-03 whitelist excludes `.gitignore`, so the entry was not added here. Suggested fix: add `site/` to `.gitignore` in a future docs cleanup PR (likely Plan 07-04 or a separate hygiene PR). Does NOT affect CI (workflows never commit `site/`); only matters for local mkdocs builds.
-- **Pre-existing ruff format pending on `scripts/_trivyignore_parser.py`, `scripts/rescan-issue-creator.py`, `scripts/scorecard-exception-check.py`** — three Phase-6-era scripts that `ruff format --check` flags. Out of scope for Plan 07-03 (whitelist excludes these files). New Plan 07-03 files all pass both `ruff check` and `ruff format --check`.
+- ~~**`site/` (mkdocs build output) not in `.gitignore`**.~~
+  → **RESOLVED** in commit 926bf9b (`.gitignore` entry added during Phase 7 PR cleanup).
+- ~~**Pre-existing ruff format pending on `scripts/_trivyignore_parser.py`, `scripts/rescan-issue-creator.py`, `scripts/scorecard-exception-check.py`**.~~
+  → **RESOLVED** in PR #47 (commit 084207c) — all three files reformatted via `uv run ruff format`.
+
+---
+
+## Remaining (carry to v2.x post-tag-cut backlog)
+
+These are Phase 6 follow-ups still marked `continue-on-error: true` in `.github/workflows/ci.yml`; SARIF still uploads so visibility is preserved.
+
+- **META-01 curly-brace UUID round-trip** (integration job): `test_inject_bitbucket_metadata_sets_all_5_keys` fails because `{xxxxxxxx-…}` UUIDs round-trip differently through `helm-template` / `get-values`. Tried `-o json` — did not fix.
+- **trivy-image `.trivyignore.bare` sidecar** (trivy-image job): `aquasecurity/trivy-action@v0.36.0` does not honor `trivyignores: .trivyignore.bare` for the 9 helm-stdlib Go CVEs. Fix: upgrade `trivy-action` OR migrate `.trivyignore` to YAML format (`.trivyignore.yaml`).
+- **trivy-dockerfile `skip-dirs` syntax** (trivy-dockerfile job): KSV-0014 / KSV-0118 chart-fixture securityContext findings leak through `skip-dirs: tests/fixtures,.planning`. Need different syntax (e.g., one `--skip-dirs` per dir via `additional-args`, or a Trivy config file).


### PR DESCRIPTION
Housekeeping update on `.planning/phases/07-documentation-site-migration-guide/deferred-items.md` — the three Phase 7 in-execution findings (ruff E501, site/ gitignore, ruff format on 3 scripts) are all resolved on main now. Remaining backlog: 3 Phase 6 follow-ups (META-01, trivy YAML, skip-dirs) still marked continue-on-error in ci.yml.

## Test plan
- [x] Pure docs change, no source code touched
- [x] Pre-commit pytest green