### PR TITLE
fix(release): smoke-test must ignore SLSA attestation-manifest entries (R2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,17 +172,36 @@ jobs:
 
       - name: Smoke-test multi-arch manifest (Pitfall #2 / R2 mitigation)
         # `imagetools inspect` lists the platforms baked into the manifest.
-        # Assertion: both linux/amd64 AND linux/arm64 present as real entries
+        # Assertion: both linux/amd64 AND linux/arm64 present as REAL entries
         # (NOT 'unknown/unknown' which is the QEMU-broken-arm64 telltale).
+        #
+        # Modern buildx adds SLSA attestation manifests as additional entries
+        # with platform=unknown/unknown and annotation
+        # `vnd.docker.reference.type=attestation-manifest`. Those are LEGITIMATE
+        # and must be excluded from the broken-platform check.
         run: |
           set -euo pipefail
-          INSPECT_OUT=$(docker buildx imagetools inspect "${{ steps.manifest.outputs.image-ref }}")
-          echo "$INSPECT_OUT"
-          echo "$INSPECT_OUT" | grep -F 'linux/amd64'
-          echo "$INSPECT_OUT" | grep -F 'linux/arm64'
-          # Defensive: fail if the manifest has any 'unknown' platform entry
-          if echo "$INSPECT_OUT" | grep -E 'Platform:.*unknown'; then
-            echo "ERROR: manifest contains an 'unknown' platform entry — Pitfall #2 (QEMU broken arm64?)" >&2
+          # Use --raw to get the actual OCI image index JSON for reliable jq parsing.
+          INSPECT_JSON=$(docker buildx imagetools inspect "${{ steps.manifest.outputs.image-ref }}" --raw)
+          echo "$INSPECT_JSON" | jq '.'
+          # Extract real platforms (excluding attestation-manifest entries).
+          REAL_PLATFORMS=$(echo "$INSPECT_JSON" | jq -r '
+            .manifests[]
+            | select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")
+            | "\(.platform.os)/\(.platform.architecture)"
+          ' | sort -u)
+          echo "Real platforms: $REAL_PLATFORMS"
+          echo "$REAL_PLATFORMS" | grep -Fx 'linux/amd64'
+          echo "$REAL_PLATFORMS" | grep -Fx 'linux/arm64'
+          # Defensive: fail if any REAL (non-attestation) manifest is unknown — that's the QEMU bug.
+          BROKEN=$(echo "$INSPECT_JSON" | jq -r '
+            .manifests[]
+            | select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")
+            | select(.platform.architecture == "unknown" or .platform.os == "unknown")
+            | "\(.platform.os)/\(.platform.architecture)"
+          ')
+          if [ -n "$BROKEN" ]; then
+            echo "ERROR: real manifest entry has unknown platform: $BROKEN — Pitfall #2 (QEMU broken arm64?)" >&2
             exit 1
           fi
 

--- a/tests/structural/test_release_yml_sign_attest.py
+++ b/tests/structural/test_release_yml_sign_attest.py
@@ -247,17 +247,25 @@ def test_sign_attest_manifest_assembly_has_three_tags(release_workflow: dict[str
 
 
 def test_sign_attest_has_qemu_smoke_check(release_workflow: dict[str, Any]) -> None:
-    """Smoke-test step must grep for 'Platform:.*unknown' — QEMU-broken arm64 guard (Pitfall #2)."""
+    """Smoke-test step must detect unknown platforms while ignoring attestation-manifests.
+
+    Pitfall #2 guard: a real (non-attestation) manifest entry with
+    platform=unknown/unknown is the QEMU-broken arm64 telltale. SLSA attestation
+    manifests legitimately carry platform=unknown/unknown plus annotation
+    ``vnd.docker.reference.type=attestation-manifest`` and must NOT trigger the
+    guard. The check uses ``jq`` on ``--raw`` JSON output to distinguish.
+    """
     steps = _get_sign_attest_steps(release_workflow)
     smoke_step: dict[str, Any] | None = None
     for step in steps:
         run_script: str = step.get("run", "")
-        if "Platform:.*unknown" in run_script:
+        if "attestation-manifest" in run_script and "imagetools inspect" in run_script:
             smoke_step = step
             break
     assert smoke_step is not None, (
-        "Pitfall #2 guard missing: no step in sign-and-attest contains 'Platform:.*unknown' — "
-        "this grep check is required to detect QEMU-broken arm64 manifests at release time."
+        "Pitfall #2 guard missing: no step in sign-and-attest filters out "
+        "'attestation-manifest' before checking for unknown platforms — this is "
+        "required so SLSA attestation manifests don't false-trip the QEMU broken-arm64 guard."
     )
     run_script = smoke_step.get("run", "")
     assert "linux/amd64" in run_script, (
@@ -266,5 +274,9 @@ def test_sign_attest_has_qemu_smoke_check(release_workflow: dict[str, Any]) -> N
     )
     assert "linux/arm64" in run_script, (
         f"Smoke-test step must assert 'linux/arm64' present in manifest inspect output; "
+        f"run script:\n{run_script}"
+    )
+    assert "unknown" in run_script, (
+        f"Smoke-test step must still check for unknown platforms (the QEMU bug); "
         f"run script:\n{run_script}"
     )


### PR DESCRIPTION
## Summary

The Pitfall #2 / R2 smoke check on the multi-arch manifest tripped on legitimate SLSA attestation-manifest entries that buildx adds with `platform=unknown/unknown` + annotation `vnd.docker.reference.type=attestation-manifest`.

### Symptom

`release.yml` on the v2.0.0 tag-push failed at the "Smoke-test multi-arch manifest" step with `manifest contains an 'unknown' platform entry — Pitfall #2 (QEMU broken arm64?)`.

In reality both `linux/amd64` and `linux/arm64` builds had succeeded; the `unknown` entries were SBOM/SLSA attestation manifests, not broken QEMU binaries.

### Fix

- `.github/workflows/release.yml`: use `docker buildx imagetools inspect --raw` + `jq` to extract REAL (non-attestation) platforms. Assert `{linux/amd64, linux/arm64}` present AND no real entry has unknown os/arch. The legitimate attestation manifests are filtered out by the `vnd.docker.reference.type != "attestation-manifest"` predicate.
- `tests/structural/test_release_yml_sign_attest.py`: assert the new shape (attestation-manifest filter + imagetools inspect + linux/amd64 + linux/arm64 + unknown keyword still present so the QEMU guard isn't accidentally removed).

## Test plan

- [x] `uv run pytest tests/structural/test_release_yml_sign_attest.py -q --no-cov` → 14 passed
- [x] `uv run pytest tests/structural/test_workflow_digest_pins.py -q --no-cov` → 4 passed (40-char SHA pinning still intact)
- [ ] CI green on this PR
- [ ] After merge: re-trigger v2.0.0 release via `gh workflow run release.yml --field tag=v2.0.0` (the v2.0.0 tag already exists; release.yml accepts manual dispatch with tag input)