### PR TITLE
fix(release): drop cosign --bundle flag (removed in cosign 2.x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,12 +206,16 @@ jobs:
           fi
 
       - name: Sign manifest with Cosign keyless (SEC-01)
-        # --bundle is REQUIRED (Pitfall #4): without it, verification needs Rekor online.
+        # cosign 2.x stores the signature + cert + Rekor inclusion proof as OCI
+        # artifacts alongside the image in the registry; no local --bundle file
+        # is needed (the v1.x --bundle flag was removed from `cosign sign` in
+        # 2.x). For offline verify, consumers fetch the registry-side bundle via
+        # `cosign download signature ${IMAGE_REF} > cosign.bundle`.
         # --yes accepts the Fulcio TOS (required in non-interactive CI).
         env:
           IMAGE_REF: ${{ steps.manifest.outputs.image-ref }}
         run: |
-          cosign sign --yes --bundle cosign.bundle "${IMAGE_REF}"
+          cosign sign --yes "${IMAGE_REF}"
 
       - name: Generate SPDX SBOM (SEC-02)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -230,10 +234,13 @@ jobs:
           upload-artifact: false
 
       - name: Attest SPDX SBOM via Cosign (CONTEXT D8)
+        # cosign 2.x: the attestation is stored as an OCI artifact alongside
+        # the image. The v1.x --bundle flag is no longer accepted on `cosign
+        # attest`; consumers verify via `cosign verify-attestation --type spdxjson`.
         env:
           IMAGE_REF: ${{ steps.manifest.outputs.image-ref }}
         run: |
-          cosign attest --yes --bundle sbom.spdx.bundle \
+          cosign attest --yes \
             --predicate sbom.spdx.json \
             --type spdxjson \
             "${IMAGE_REF}"
@@ -242,7 +249,7 @@ jobs:
         env:
           IMAGE_REF: ${{ steps.manifest.outputs.image-ref }}
         run: |
-          cosign attest --yes --bundle sbom.cyclonedx.bundle \
+          cosign attest --yes \
             --predicate sbom.cyclonedx.json \
             --type cyclonedx \
             "${IMAGE_REF}"
@@ -264,17 +271,20 @@ jobs:
           VERSION: ${{ steps.tags.outputs.version }}
         run: |
           set -euo pipefail
+          # Cosign 2.x stores signatures + attestations as OCI artifacts in the
+          # registry alongside the image. Only the raw SBOM JSON files are
+          # attached to the GitHub Release for human convenience; the canonical
+          # supply-chain artifacts (signature, cert, Rekor entry, attestations)
+          # live at ${IMAGE_REF} and are fetched via `cosign verify*`.
           if gh release view "v${VERSION}" >/dev/null 2>&1; then
             gh release upload "v${VERSION}" \
               sbom.spdx.json sbom.cyclonedx.json \
-              cosign.bundle sbom.spdx.bundle sbom.cyclonedx.bundle \
               --clobber
             gh release edit "v${VERSION}" --notes-file <(gh release view "v${VERSION}" --json body --jq .body; echo -e "\n\n## Supply chain artifacts\n\n- Manifest: \`${IMAGE_REF}\`\n- Cosign verify: \`cosign verify --certificate-identity-regexp '^https://github.com/${{ github.repository }}/' --certificate-oidc-issuer https://token.actions.githubusercontent.com ${IMAGE_REF}\`\n- SBOM (SPDX): \`cosign verify-attestation --type spdxjson ${IMAGE_REF}\`\n- SBOM (CycloneDX): \`cosign verify-attestation --type cyclonedx ${IMAGE_REF}\`")
           else
             echo "WARNING: GitHub Release v${VERSION} not found — release-please may have failed or this is workflow_dispatch" >&2
             gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes \
-              sbom.spdx.json sbom.cyclonedx.json \
-              cosign.bundle sbom.spdx.bundle sbom.cyclonedx.bundle
+              sbom.spdx.json sbom.cyclonedx.json
           fi
 
   benchmark-cold-start:

--- a/tests/structural/test_release_yml_sign_attest.py
+++ b/tests/structural/test_release_yml_sign_attest.py
@@ -1,6 +1,6 @@
 """Structural tests for the sign-and-attest job in .github/workflows/release.yml.
 
-Phase 6 / SEC-01 / SEC-02 / SEC-03 / CI-03. Asserts: cosign keyless + bundle,
+Phase 6 / SEC-01 / SEC-02 / SEC-03 / CI-03. Asserts: cosign keyless (registry-side bundle in 2.x),
 both SBOM formats attested, SLSA provenance via attest-build-provenance@v4 (RESEARCH C1).
 """
 
@@ -125,19 +125,30 @@ def test_sign_attest_installs_cosign_v_2_6_3(release_workflow: dict[str, Any]) -
     )
 
 
-def test_sign_attest_signs_with_bundle(release_workflow: dict[str, Any]) -> None:
-    """cosign sign step must include --bundle cosign.bundle — Pitfall #4: offline verifiability."""
+def test_sign_attest_has_cosign_sign_step(release_workflow: dict[str, Any]) -> None:
+    """A cosign sign step against the image manifest must exist (SEC-01).
+
+    Cosign 2.x stores signature + cert + Rekor inclusion proof as OCI artifacts
+    alongside the image in the registry; no local `--bundle` file is required.
+    The v1.x `--bundle` flag was removed from `cosign sign` in 2.x.
+    Consumers fetch the registry-side bundle for offline verify via
+    ``cosign download signature ${IMAGE_REF} > cosign.bundle``.
+    """
     steps = _get_sign_attest_steps(release_workflow)
     found = False
     for step in steps:
         run_script: str = step.get("run", "")
-        if "cosign sign" in run_script and "--bundle cosign.bundle" in run_script:
+        if "cosign sign" in run_script and "--yes" in run_script:
             found = True
+            # Guard against re-introducing the v1.x --bundle flag (regression check).
+            assert "--bundle" not in run_script, (
+                "cosign 2.x: `cosign sign` does NOT accept `--bundle` (removed). "
+                "Use registry-side artifacts; see SEC-01 step comment."
+            )
             break
     assert found, (
-        "Pitfall #4 violation: no 'cosign sign --bundle cosign.bundle' step found in "
-        "sign-and-attest job. Without --bundle, offline verification requires Rekor (online). "
-        "See 06-RESEARCH.md §Common Pitfalls #4."
+        "SEC-01 violation: no `cosign sign --yes <image>` step found in sign-and-attest job. "
+        "Cosign 2.x keyless image signing requires this exact invocation shape."
     )
 
 


### PR DESCRIPTION
## Summary

cosign 2.x removed the v1.x `--bundle` flag from both `cosign sign` and `cosign attest`. The pinned v2.6.3 used by `sigstore/cosign-installer` fails with `unknown flag: --bundle` on the v2.0.0 release run.

Cosign 2.x stores signature + cert + Rekor inclusion proof and attestations as OCI artifacts in the registry alongside the image; no local bundle file is needed. Consumers fetch the registry-side bundle for offline verify via:

```bash
cosign download signature <IMAGE_REF> > cosign.bundle
```

### Changes

- Drop `--bundle` from `cosign sign` and both `cosign attest` invocations.
- Drop `cosign.bundle` / `sbom.*.bundle` from GitHub Release upload artifacts; only the raw SBOM JSON files remain attached (canonical artifacts live in the registry; release body documents the `cosign verify` commands).
- Replace `test_sign_attest_signs_with_bundle` with `test_sign_attest_has_cosign_sign_step` that asserts the new shape AND **regression-guards** against re-introducing `--bundle`.
- Update module docstring to reflect "registry-side bundle in 2.x".

### Test plan

- [x] `uv run pytest tests/structural/test_release_yml_sign_attest.py -q --no-cov` → 14 passed
- [ ] CI green on this PR
- [ ] After merge: re-run release.yml for v2.0.0 via workflow_dispatch with `tag=v2.0.0`