### PR TITLE
fix(release): benchmark needs packages:read + GHCR login (IMAGE-06)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      packages: read   # `docker pull ghcr.io/...` of the just-published image
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -306,6 +307,13 @@ jobs:
             REF="${{ inputs.tag }}"
           fi
           echo "tag=${REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR (read-only pull access for the cold-start benchmark)
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run benchmark
         run: |


### PR DESCRIPTION
## Summary

The benchmark cold-start job in release.yml pulls the just-published GHCR image. Without `packages:read` on the job AND a `docker/login-action` step, the pull fails silently (the benchmark script uses `set -euo pipefail` and silences pull stderr).

Surfaced on the final v2.0.0 ceremony run: tag resolution was correct (`v2.0.0` after PR #53), but `docker pull ghcr.io/.../v2.0.0` failed because the runner had no GHCR auth.

## Fix

- Add `packages: read` to the benchmark job's permissions block.
- Add a `docker/login-action@<v4.2.0 SHA>` step (same digest pin used by the upstream build + sign-and-attest jobs in this workflow, so `test_workflow_digest_pins.py` stays green).

## Test plan

- [x] Pre-commit pytest green
- [ ] CI green on this PR
- [ ] After merge: final re-run of release.yml for v2.0.0 → all 4 jobs green (build amd64, build arm64, sign+SBOM+SLSA, benchmark)