### PR TITLE
fix(release): benchmark must strip 'v' prefix to match GHCR tag scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,7 +306,10 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag }}" ]; then
             REF="${{ inputs.tag }}"
           fi
-          echo "tag=${REF}" >> "$GITHUB_OUTPUT"
+          # Strip the leading "v" — the sign-and-attest job tags the GHCR
+          # manifest as :MAJOR.MINOR.PATCH, :MAJOR, and :latest (no "v" prefix).
+          VERSION="${REF#v}"
+          echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR (read-only pull access for the cold-start benchmark)
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0


### PR DESCRIPTION
## Summary

The sign-and-attest job tags the GHCR manifest as `:MAJOR.MINOR.PATCH`, `:MAJOR`, `:latest` (no `v` prefix). The benchmark step was passing the raw `v2.0.0` ref-name, which doesn't exist on GHCR — so `docker pull` failed silently (the benchmark script uses `set -euo pipefail` and silences pull stderr).

## Fix

Strip the leading `v` in the benchmark's `resolve_tag` step. Input `v2.0.0` → output `2.0.0`.

## Test plan

- [x] Pre-commit pytest green
- [ ] CI green on this PR
- [ ] After merge: final release.yml re-run for v2.0.0 → all 4 jobs green