### PR TITLE
chore(security): freeze v1.x EOS date — 2026-12-23

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version | Supported              |
 |---------|------------------------|
 | 2.x     | Yes (active development on `main`) |
-| 1.x     | Security fixes for 6 months from the v2.0.0 release date — ending `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` Frozen at v1.3.0 on Docker Hub. |
+| 1.x     | Security fixes for 6 months from the v2.0.0 release date — ending `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months). Frozen at v1.3.0 on Docker Hub. |
 
 ## Reporting a vulnerability
 

--- a/docs/admin/repo-settings.md
+++ b/docs/admin/repo-settings.md
@@ -312,9 +312,8 @@ with a side-by-side `mkdocs.yml` pointing at a tiny `docs/` tree):**
 # 1. Stage v1 snapshot source under a gitignored directory.
 mkdir -p .v1-snapshot/docs
 
-# 2. Author a minimal docs/index.md with the "v1 frozen" banner — note the
-#    `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.`
-#    placeholder (SI-07-07; replaced in the v1.x-EOS follow-up PR).
+# 2. Author a minimal docs/index.md with the "v1 frozen" banner — the v1.x
+#    EOS is `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months; per D10).
 cat > .v1-snapshot/docs/index.md <<'EOF'
 # aws-eks-helm-deploy v1 — frozen
 
@@ -322,7 +321,7 @@ cat > .v1-snapshot/docs/index.md <<'EOF'
     The v1.x line of this pipe was distributed via Docker Hub at
     `yvogl/aws-eks-helm-deploy` and is **frozen at v1.3.0**.
     Security fixes for v1.x are released for **6 months from the v2.0.0
-    release date** — ending `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.`
+    release date** — ending `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months).
 
     Use **v2** for all new and existing deployments:
     <https://yves-vogl.github.io/aws-eks-helm-deploy/v2/>
@@ -405,7 +404,7 @@ above the existing content):
 > version (`:2.0.0`).
 >
 > Security fixes for v1.x are released for 6 months from the v2.0.0 release
-> date — ending `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.`
+> date — ending `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months).
 >
 > Migration guide: https://yves-vogl.github.io/aws-eks-helm-deploy/migration/v1-to-v2/
 ```
@@ -462,8 +461,9 @@ gh label list --repo $REPO --json name --jq 'length'
   intent — re-running is harmless but unnecessary).
 - Sections 10–11 (Bitbucket Pipe Marketplace + Docker Hub banner) are web-UI
   only with no programmatic idempotency guarantee; confirm visually.
-- The literal placeholder `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.`
-  is the SI-07-07 invariant; it appears in v2.0 in `SECURITY.md` (Plan 07-06),
+- The v1.x EOS date is `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months;
+  per D10 / SI-07-07). It appears in `SECURITY.md` (Plan 07-06),
   `docs/migration/v1-to-v2.md` (Plan 07-04), AND `docs/admin/repo-settings.md`
-  Section 9 + 11 (this plan). After the v2.0.0 tag-cut, the maintainer
-  replaces all occurrences in a single follow-up PR.
+  Sections 9 + 11 (this plan). The pre-tag-cut placeholder
+  `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` was
+  replaced in the v1.x-EOS-freeze follow-up PR after v2.0.0 was tagged.

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -1,6 +1,6 @@
 # v1 → v2 Migration Guide
 
-> **Status:** Published. This guide covers every v1.x → v2.0 breaking change. The 6-month v1.x security window ends `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` (per D10).
+> **Status:** Published. This guide covers every v1.x → v2.0 breaking change. The 6-month v1.x security window ends `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months; per D10).
 
 [TOC]
 

--- a/tests/structural/test_migration_guide.py
+++ b/tests/structural/test_migration_guide.py
@@ -36,9 +36,10 @@ REQUIRED_BREAKING_CHANGE_TOKENS: frozenset[str] = frozenset(
     },
 )
 
-# SI-07-07 gate: the D10 placeholder appears verbatim in this file AND in
-# SECURITY.md (Plan 07-06). Tag-cut replaces the literal string.
-D10_PLACEHOLDER = "2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut."
+# SI-07-07 gate (post tag-cut): the v1.x EOS date appears verbatim in this
+# file AND in SECURITY.md (Plan 07-06). v2.0.0 was released 2026-06-23,
+# so EOS = 2026-12-23 (6 months later).
+V1_EOS_DATE = "2026-12-23"
 
 
 # ---------------------------------------------------------------------------
@@ -83,12 +84,10 @@ def test_migration_guide_covers_inject_bitbucket_metadata() -> None:
     )
 
 
-def test_migration_guide_has_d10_six_month_placeholder() -> None:
-    """SI-07-07 gate: the D10 6-month placeholder is committed verbatim."""
+def test_migration_guide_has_v1_eos_date() -> None:
+    """SI-07-07 gate (post tag-cut): the v1.x EOS date is committed verbatim."""
     text = MIGRATION_MD.read_text(encoding="utf-8")
-    assert D10_PLACEHOLDER in text, (
-        f"D10 placeholder string missing from {MIGRATION_MD}; expected literal: {D10_PLACEHOLDER!r}"
-    )
+    assert V1_EOS_DATE in text, f"v1.x EOS date `{V1_EOS_DATE}` missing from {MIGRATION_MD}"
 
 
 def test_migration_guide_cross_references_examples_diff() -> None:

--- a/tests/structural/test_repo_settings_runbook.py
+++ b/tests/structural/test_repo_settings_runbook.py
@@ -9,9 +9,10 @@ v2.0.0 release ceremony per D11 (Phase 6 §§5-6 + §12 restored alongside):
 - Section 10: Update Bitbucket Pipe Marketplace listing (D11).
 - Section 11: Post Docker Hub README deprecation banner (MIG-01 / D10).
 
-Also asserts the SI-07-07 invariant: the D10 placeholder
-'2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.' appears
-at least twice in the runbook (sections 9 + 11).
+Also asserts the SI-07-07 invariant: the v1.x EOS date `2026-12-23`
+(v2.0.0 released 2026-06-23 + 6 months) appears at least twice in the
+runbook (sections 9 + 11). The pre-tag-cut placeholder was replaced
+after v2.0.0 was tagged on 2026-06-23.
 """
 
 from __future__ import annotations
@@ -23,7 +24,7 @@ import pytest
 pytestmark = pytest.mark.unit
 
 RUNBOOK = pathlib.Path(__file__).resolve().parents[2] / "docs" / "admin" / "repo-settings.md"
-D10_PLACEHOLDER = "2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut."
+V1_EOS_DATE = "2026-12-23"
 
 
 def test_runbook_exists() -> None:
@@ -94,12 +95,12 @@ def test_runbook_has_docker_hub_banner_section() -> None:
     )
 
 
-def test_runbook_propagates_d10_placeholder() -> None:
-    """SI-07-07: the D10 6-month placeholder must appear ≥ 2 times (Sections 9 + 11)."""
+def test_runbook_propagates_v1_eos_date() -> None:
+    """SI-07-07: the v1.x EOS date 2026-12-23 must appear ≥ 2 times (Sections 9 + 11)."""
     text = RUNBOOK.read_text()
-    count = text.count(D10_PLACEHOLDER)
+    count = text.count(V1_EOS_DATE)
     assert count >= 2, (
-        f"SI-07-07 invariant broken: D10 placeholder appears {count} time(s), "
+        f"SI-07-07 invariant broken: v1.x EOS date `{V1_EOS_DATE}` appears {count} time(s), "
         f"expected ≥ 2 (Section 9 v1 banner + Section 11 Docker Hub banner)"
     )
 

--- a/tests/structural/test_security_md.py
+++ b/tests/structural/test_security_md.py
@@ -19,9 +19,9 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 SECURITY_MD = REPO_ROOT / "SECURITY.md"
 
-# D10 verbatim placeholder — SI-07-07 grep gate enforces byte-for-byte equality
-# across SECURITY.md AND docs/migration/v1-to-v2.md.
-D10_PLACEHOLDER = "2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut."
+# Post tag-cut: the v1.x EOS date is now absolute (SI-07-07 invariant).
+# v2.0.0 was released 2026-06-23 → EOS = 2026-12-23.
+V1_EOS_DATE = "2026-12-23"
 
 
 # ---------------------------------------------------------------------------
@@ -34,12 +34,12 @@ def test_security_md_exists() -> None:
     assert SECURITY_MD.is_file(), f"SECURITY.md missing at {SECURITY_MD}"
 
 
-def test_security_md_has_d10_six_month_placeholder() -> None:
-    """SI-07-07 gate: the D10 placeholder must be present verbatim."""
+def test_security_md_has_v1_eos_date() -> None:
+    """SI-07-07 gate: the v1.x EOS date 2026-12-23 must be present verbatim."""
     text = SECURITY_MD.read_text(encoding="utf-8")
-    assert D10_PLACEHOLDER in text, (
-        "SECURITY.md must contain the D10 6-month placeholder verbatim "
-        f"({D10_PLACEHOLDER!r}). SI-07-07 gate failure."
+    assert V1_EOS_DATE in text, (
+        f"SECURITY.md must contain the v1.x EOS date `{V1_EOS_DATE}` "
+        "(v2.0.0 released 2026-06-23 + 6 months). SI-07-07 gate failure."
     )
 
 


### PR DESCRIPTION
## Summary

v2.0.0 was tagged on **2026-06-23** and released successfully (all 4 release.yml jobs green: build amd64 + arm64 + sign + SBOM (SPDX + CycloneDX) + SLSA + benchmark).

This PR replaces the pre-tag-cut placeholder `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` with the **absolute v1.x EOS date** `2026-12-23` (release date + 6 months per D10) everywhere it appeared:

| File | Section |
|---|---|
| `SECURITY.md` | Supported-versions row |
| `docs/migration/v1-to-v2.md` | Status admonition |
| `docs/admin/repo-settings.md` | §9 v1 frozen banner, §11 Docker Hub banner, Notes |

Structural tests updated to assert the absolute date instead of the placeholder:

- `test_security_md.py`: `D10_PLACEHOLDER` → `V1_EOS_DATE`
- `test_migration_guide.py`: `D10_PLACEHOLDER` → `V1_EOS_DATE`
- `test_repo_settings_runbook.py`: `D10_PLACEHOLDER` → `V1_EOS_DATE`; test renamed `test_runbook_propagates_d10_placeholder` → `test_runbook_propagates_v1_eos_date`

## v2.0.0 ceremony status

| Step | Status |
|---|---|
| v2.0.0 tag pushed | ✅ |
| release.yml: build amd64 + arm64 | ✅ |
| release.yml: sign + SBOM (SPDX + CycloneDX) + SLSA | ✅ |
| release.yml: benchmark cold-start | ✅ |
| GitHub Release v2.0.0 with SBOM assets | ✅ |
| GHCR images: `:2.0.0`, `:2`, `:latest` | ✅ |
| GitHub Pages enabled | ✅ |
| `mike set-default v2` (root → /v2/) | ✅ |
| `mike deploy v1` (frozen snapshot) | ✅ |
| https://yves-vogl.github.io/aws-eks-helm-deploy/v1/ live | ✅ |
| https://yves-vogl.github.io/aws-eks-helm-deploy/v2/ live | ✅ |
| v1.x EOS date frozen at `2026-12-23` | this PR |
| Bitbucket Pipe Marketplace listing update | web-UI only — Yves |
| Docker Hub README deprecation banner | web-UI only — Yves |

## Test plan

- [x] `uv run pytest tests/structural -q --no-cov` → 200 passed
- [ ] CI green on this PR