### PR TITLE
fix(security): scorecard publish, trivy-secret false-positives on .venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,18 @@ jobs:
           skip-dirs: tests/fixtures,.planning
 
       - name: Run Trivy secret scan (filesystem)
-        # TODO(post-Phase-6): finds test-fixture dummy secrets; needs skip-dirs.
+        # skip-dirs excludes:
+        #  - `.venv/`: uv-generated virtualenv with third-party libraries that
+        #    embed placeholder mock-secrets (e.g. `moto`'s dummy AWS credentials).
+        #    These are not project secrets and surfaced as Critical findings in
+        #    the Security tab (alert #163 etc.).
+        #  - `tests/fixtures/`: chart fixtures that intentionally use dummy
+        #    secret-shaped strings for test ergonomics.
+        #  - `.planning/`: planning docs may quote example credentials in
+        #    threat-model walkthroughs.
+        # `continue-on-error: true` stays as a defense-in-depth so a single
+        # false-positive can never block a release; the SARIF upload still
+        # surfaces real findings to the Security tab.
         continue-on-error: true
         id: trivy-secret
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -229,6 +240,7 @@ jobs:
           exit-code: "1"
           format: sarif
           output: trivy-secret.sarif
+          skip-dirs: .venv,tests/fixtures,.planning
 
       - name: Upload secret-scan SARIF to Code Scanning
         # Only upload when Trivy actually wrote a SARIF file. With zero secret-scan

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,28 +32,19 @@ jobs:
       id-token: write
       contents: read
       actions: read
+    # IMPORTANT: when `publish_results: true`, ossf/scorecard-action verifies the
+    # workflow on api.securityscorecards.dev and REJECTS any step outside its
+    # narrow whitelist (checkout + scorecard-action + upload-artifact +
+    # codeql/upload-sarif). Earlier revisions had `astral-sh/setup-uv` here for
+    # the `.scorecard-exception.md` D3 grammar check — that triggered an HTTP
+    # 400 "workflow verification failed: unallowed step" on every run. The
+    # D3 grammar check now lives in `tests/structural/test_scorecard_exception_grammar.py`
+    # (runs via ci.yml unit-coverage job); this workflow is kept minimal.
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          version: "0.11.21"
-
-      - name: Set up Python
-        run: uv python install 3.13
-
-      - name: Install dependencies
-        run: uv sync --all-extras --frozen
-
-      - name: Validate .scorecard-exception.md (D3 stale-detection)
-        run: |
-          if [[ -f .scorecard-exception.md ]]; then
-            uv run python scripts/scorecard-exception-check.py .scorecard-exception.md
-          fi
 
       - name: Run Scorecard analysis
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3

--- a/tests/structural/test_scorecard_exception_grammar.py
+++ b/tests/structural/test_scorecard_exception_grammar.py
@@ -1,0 +1,48 @@
+"""Structural test for .scorecard-exception.md D3 grammar (SEC-10).
+
+Runs the existing `scripts/scorecard-exception-check.py` validator as a
+structural test so the grammar gate runs on every push via the unit-coverage
+CI job. Previously this lived as a step in `.github/workflows/scorecard.yml`,
+but that workflow must stay minimal — `ossf/scorecard-action` rejects any
+non-whitelisted step (e.g. `astral-sh/setup-uv`) when `publish_results: true`
+(HTTP 400, "workflow verification failed: unallowed step").
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+EXCEPTION_MD = REPO_ROOT / ".scorecard-exception.md"
+CHECKER = REPO_ROOT / "scripts" / "scorecard-exception-check.py"
+
+
+def test_checker_script_exists() -> None:
+    """The D3 grammar validator script must exist."""
+    assert CHECKER.is_file(), f"missing: {CHECKER}"
+
+
+def test_scorecard_exception_grammar_valid() -> None:
+    """Run the D3 grammar validator on `.scorecard-exception.md` if present.
+
+    Skips if the file is absent (the exception file is optional — only present
+    when an OSSF Scorecard check is intentionally being suppressed).
+    """
+    if not EXCEPTION_MD.exists():
+        pytest.skip("no .scorecard-exception.md present — nothing to validate")
+    result = subprocess.run(
+        [sys.executable, str(CHECKER), str(EXCEPTION_MD)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f".scorecard-exception.md fails D3 grammar:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Two CI failures spotted post-v2.0.0:

### 1. Scorecard workflow returned HTTP 400

`scorecard.yml` returned `workflow verification failed: job has unallowed step: astral-sh/setup-uv` on every run. `ossf/scorecard-action` verifies the workflow on `api.securityscorecards.dev` when `publish_results: true` and REJECTS any step outside its narrow whitelist (checkout + scorecard-action + upload-artifact + codeql/upload-sarif).

**Fix:** strip `setup-uv` + Python install + `uv sync` + the inline D3 grammar check from `scorecard.yml`. The D3 grammar check moves to `tests/structural/test_scorecard_exception_grammar.py` and runs on every push via the existing unit-coverage CI job.

### 2. trivy-secret false positives on `.venv/` (Code Scanning #163)

`trivy-secret` in `ci.yml` had no `skip-dirs`, so it scanned the uv-generated `.venv/` on the runner. That picked up moto's dummy `requester_id = ********************` placeholder as `CRITICAL: Secret AWS Access Key ID` (Code Scanning alert #163), plus other false positives in `tests/fixtures` and `.planning`.

**Fix:** add `skip-dirs: .venv,tests/fixtures,.planning` to the trivy-secret step. `continue-on-error: true` stays as defense-in-depth.

## Test plan

- [x] `uv run pytest tests/structural -q --no-cov` → 202 passed
- [ ] CI green on this PR
- [ ] After merge: confirm scorecard.yml succeeds + Code Scanning alert #163 closes on next push