### PR TITLE
docs(security): v1.x is NOT maintained — drop misleading 6-month window claim

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version | Supported              |
 |---------|------------------------|
 | 2.x     | Yes (active development on `main`) |
-| 1.x     | Security fixes for 6 months from the v2.0.0 release date — ending `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months). Frozen at v1.3.0 on Docker Hub. |
+| 1.x     | **Not maintained.** Frozen at v1.3.0 on Docker Hub. No security fixes are committed to v1.x; please migrate to v2.x. |
 
 ## Reporting a vulnerability
 

--- a/docs/admin/repo-settings.md
+++ b/docs/admin/repo-settings.md
@@ -312,16 +312,14 @@ with a side-by-side `mkdocs.yml` pointing at a tiny `docs/` tree):**
 # 1. Stage v1 snapshot source under a gitignored directory.
 mkdir -p .v1-snapshot/docs
 
-# 2. Author a minimal docs/index.md with the "v1 frozen" banner — the v1.x
-#    EOS is `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months; per D10).
+# 2. Author a minimal docs/index.md with the "v1 frozen" banner.
 cat > .v1-snapshot/docs/index.md <<'EOF'
 # aws-eks-helm-deploy v1 — frozen
 
-!!! warning "v1.x is frozen"
+!!! warning "v1.x is not maintained"
     The v1.x line of this pipe was distributed via Docker Hub at
-    `yvogl/aws-eks-helm-deploy` and is **frozen at v1.3.0**.
-    Security fixes for v1.x are released for **6 months from the v2.0.0
-    release date** — ending `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months).
+    `yvogl/aws-eks-helm-deploy` and is **frozen at v1.3.0**. No active
+    maintenance is provided — no security patches, no bug fixes.
 
     Use **v2** for all new and existing deployments:
     <https://yves-vogl.github.io/aws-eks-helm-deploy/v2/>
@@ -398,15 +396,14 @@ https://hub.docker.com/repository/docker/yvogl/aws-eks-helm-deploy/general
 above the existing content):
 
 ```markdown
-> **⚠️ Deprecated.** v1.3.0 is the final v1.x image and is frozen on Docker
-> Hub. New consumers should pull v2.x from GitHub Container Registry at
-> `ghcr.io/yves-vogl/aws-eks-helm-deploy` (rolling `:2` tag) or a pinned
-> version (`:2.0.0`).
+> **⚠️ Not maintained.** v1.3.0 is the final v1.x image and is **frozen** on
+> Docker Hub. No security patches or bug fixes will be released for v1.x.
 >
-> Security fixes for v1.x are released for 6 months from the v2.0.0 release
-> date — ending `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months).
+> New consumers — and existing v1 users — should pull v2.x from GitHub
+> Container Registry at `ghcr.io/yves-vogl/aws-eks-helm-deploy` (rolling `:2`
+> tag) or a pinned version (`:2.0.0`).
 >
-> Migration guide: https://yves-vogl.github.io/aws-eks-helm-deploy/migration/v1-to-v2/
+> Migration guide: https://yves-vogl.github.io/aws-eks-helm-deploy/v2/migration/v1-to-v2/
 ```
 
 Web-UI only step; no API. **Not idempotent via API.** Confirm visually after
@@ -461,9 +458,9 @@ gh label list --repo $REPO --json name --jq 'length'
   intent — re-running is harmless but unnecessary).
 - Sections 10–11 (Bitbucket Pipe Marketplace + Docker Hub banner) are web-UI
   only with no programmatic idempotency guarantee; confirm visually.
-- The v1.x EOS date is `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months;
-  per D10 / SI-07-07). It appears in `SECURITY.md` (Plan 07-06),
-  `docs/migration/v1-to-v2.md` (Plan 07-04), AND `docs/admin/repo-settings.md`
-  Sections 9 + 11 (this plan). The pre-tag-cut placeholder
-  `2026-MM-DD (= v2.0.0 release date + 6 months) — replace at tag-cut.` was
-  replaced in the v1.x-EOS-freeze follow-up PR after v2.0.0 was tagged.
+- **v1.x is not maintained.** The v1.3.0 image on Docker Hub is the final v1
+  release; no security patches or bug fixes are committed to v1.x. The original
+  Phase 7 design assumed a 6-month security-fix window (D10 / SI-07-07 placeholder),
+  but the policy was revised post-v2.0.0 to a clean break — users should migrate
+  to v2.x. SECURITY.md, the migration guide, and §§9 + 11 of this runbook all
+  carry the "not maintained" wording verbatim.

--- a/docs/adr/0002-v2-clean-break.md
+++ b/docs/adr/0002-v2-clean-break.md
@@ -51,7 +51,7 @@ Chosen option: **"Clean break with migration guide"**, because v1.x has a mainta
 * Good, because v2 codebase stays clean and modern.
 * Good, because the migration boundary is visible (different registry, different image, different version).
 * Bad, because consumers must consciously read the migration guide.
-* Neutral, because v1.x retains a security-supported path for 6 months (D10).
+* Bad, because v1.x is **not maintained** — no security fixes, no bug fixes (clean-break policy revised post-v2.0.0 from the original Phase 7 D10 6-month window).
 
 ### Versioned API (runtime compat flag)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ and supply-chain hardened. v2.x is the active line; v1.x is frozen.
 This site uses [mike](https://github.com/jimporter/mike) for versioning:
 
 - `/v2/` — current (this site).
-- `/v1/` — frozen v1.3.0 reference; security-only patches until 6 months post-v2.0.0 release.
+- `/v1/` — frozen v1.3.0 reference (not maintained; users should migrate to v2).
 
 ## Supply chain
 

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -1,6 +1,6 @@
 # v1 → v2 Migration Guide
 
-> **Status:** Published. This guide covers every v1.x → v2.0 breaking change. The 6-month v1.x security window ends `2026-12-23` (v2.0.0 released 2026-06-23 + 6 months; per D10).
+> **Status:** Published. This guide covers every v1.x → v2.0 breaking change. **v1.x is frozen at v1.3.0 on Docker Hub and is not maintained** — migrate to v2.x.
 
 [TOC]
 

--- a/tests/structural/test_migration_guide.py
+++ b/tests/structural/test_migration_guide.py
@@ -36,10 +36,11 @@ REQUIRED_BREAKING_CHANGE_TOKENS: frozenset[str] = frozenset(
     },
 )
 
-# SI-07-07 gate (post tag-cut): the v1.x EOS date appears verbatim in this
-# file AND in SECURITY.md (Plan 07-06). v2.0.0 was released 2026-06-23,
-# so EOS = 2026-12-23 (6 months later).
-V1_EOS_DATE = "2026-12-23"
+# v1.x maintenance policy: NOT maintained (post-v2.0.0 clean break, see
+# SECURITY.md). The original Phase 7 plan (D10 / SI-07-07) committed to a
+# 6-month security-fix window — that was dropped after v2.0.0. The migration
+# guide must say so unambiguously.
+V1_NOT_MAINTAINED_WORDING = "not maintained"
 
 
 # ---------------------------------------------------------------------------
@@ -84,10 +85,13 @@ def test_migration_guide_covers_inject_bitbucket_metadata() -> None:
     )
 
 
-def test_migration_guide_has_v1_eos_date() -> None:
-    """SI-07-07 gate (post tag-cut): the v1.x EOS date is committed verbatim."""
+def test_migration_guide_states_v1_not_maintained() -> None:
+    """v1.x policy: not maintained (clean break post-v2.0.0)."""
     text = MIGRATION_MD.read_text(encoding="utf-8")
-    assert V1_EOS_DATE in text, f"v1.x EOS date `{V1_EOS_DATE}` missing from {MIGRATION_MD}"
+    assert V1_NOT_MAINTAINED_WORDING in text.lower(), (
+        f"migration guide must contain `{V1_NOT_MAINTAINED_WORDING}` "
+        "(post-v2.0.0 policy: v1.x has no maintenance window)."
+    )
 
 
 def test_migration_guide_cross_references_examples_diff() -> None:

--- a/tests/structural/test_repo_settings_runbook.py
+++ b/tests/structural/test_repo_settings_runbook.py
@@ -9,10 +9,10 @@ v2.0.0 release ceremony per D11 (Phase 6 §§5-6 + §12 restored alongside):
 - Section 10: Update Bitbucket Pipe Marketplace listing (D11).
 - Section 11: Post Docker Hub README deprecation banner (MIG-01 / D10).
 
-Also asserts the SI-07-07 invariant: the v1.x EOS date `2026-12-23`
-(v2.0.0 released 2026-06-23 + 6 months) appears at least twice in the
-runbook (sections 9 + 11). The pre-tag-cut placeholder was replaced
-after v2.0.0 was tagged on 2026-06-23.
+Also asserts the v1.x maintenance policy: the "not maintained" wording
+appears at least twice in the runbook (sections 9 + 11). The original
+Phase 7 SI-07-07 placeholder + 6-month-window framing was dropped
+post-v2.0.0 in favor of a clean break.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ import pytest
 pytestmark = pytest.mark.unit
 
 RUNBOOK = pathlib.Path(__file__).resolve().parents[2] / "docs" / "admin" / "repo-settings.md"
-V1_EOS_DATE = "2026-12-23"
+V1_NOT_MAINTAINED_WORDING = "not maintained"
 
 
 def test_runbook_exists() -> None:
@@ -95,13 +95,17 @@ def test_runbook_has_docker_hub_banner_section() -> None:
     )
 
 
-def test_runbook_propagates_v1_eos_date() -> None:
-    """SI-07-07: the v1.x EOS date 2026-12-23 must appear ≥ 2 times (Sections 9 + 11)."""
-    text = RUNBOOK.read_text()
-    count = text.count(V1_EOS_DATE)
+def test_runbook_propagates_v1_not_maintained_wording() -> None:
+    """v1.x policy: 'not maintained' must appear ≥ 2 times (Sections 9 + 11).
+
+    Sections 9 (v1 frozen-snapshot index.md banner heredoc) and 11 (Docker Hub
+    deprecation banner template) both carry the consumer-facing wording.
+    """
+    text = RUNBOOK.read_text().lower()
+    count = text.count(V1_NOT_MAINTAINED_WORDING)
     assert count >= 2, (
-        f"SI-07-07 invariant broken: v1.x EOS date `{V1_EOS_DATE}` appears {count} time(s), "
-        f"expected ≥ 2 (Section 9 v1 banner + Section 11 Docker Hub banner)"
+        f"v1.x maintenance policy: `{V1_NOT_MAINTAINED_WORDING}` appears {count} time(s); "
+        f"expected ≥ 2 (Section 9 v1 banner + Section 11 Docker Hub banner)."
     )
 
 

--- a/tests/structural/test_security_md.py
+++ b/tests/structural/test_security_md.py
@@ -19,9 +19,10 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 SECURITY_MD = REPO_ROOT / "SECURITY.md"
 
-# Post tag-cut: the v1.x EOS date is now absolute (SI-07-07 invariant).
-# v2.0.0 was released 2026-06-23 → EOS = 2026-12-23.
-V1_EOS_DATE = "2026-12-23"
+# v1.x maintenance policy: NOT maintained — the 6-month security-fix window
+# from the original Phase 7 design (D10 / SI-07-07) was dropped post-v2.0.0
+# to a clean break. SECURITY.md must say so unambiguously.
+V1_NOT_MAINTAINED_WORDING = "Not maintained"
 
 
 # ---------------------------------------------------------------------------
@@ -34,20 +35,17 @@ def test_security_md_exists() -> None:
     assert SECURITY_MD.is_file(), f"SECURITY.md missing at {SECURITY_MD}"
 
 
-def test_security_md_has_v1_eos_date() -> None:
-    """SI-07-07 gate: the v1.x EOS date 2026-12-23 must be present verbatim."""
-    text = SECURITY_MD.read_text(encoding="utf-8")
-    assert V1_EOS_DATE in text, (
-        f"SECURITY.md must contain the v1.x EOS date `{V1_EOS_DATE}` "
-        "(v2.0.0 released 2026-06-23 + 6 months). SI-07-07 gate failure."
-    )
+def test_security_md_states_v1_not_maintained() -> None:
+    """v1.x maintenance policy: NOT maintained.
 
-
-def test_security_md_mentions_v1_x_six_month_window() -> None:
-    """DOC-06: the v1.x supported-versions row mentions the 6-month security-fix window."""
+    The original Phase 7 design assumed a 6-month security-fix window for v1.x
+    (D10 / SI-07-07). Policy revised post-v2.0.0 to a clean break — SECURITY.md
+    must say "Not maintained" so readers don't expect patches.
+    """
     text = SECURITY_MD.read_text(encoding="utf-8")
-    assert "6 months" in text, (
-        "SECURITY.md must mention the 6-month security-fix window for v1.x (DOC-06 / D10)."
+    assert V1_NOT_MAINTAINED_WORDING in text, (
+        f"SECURITY.md must contain `{V1_NOT_MAINTAINED_WORDING}` in the v1.x "
+        "supported-versions row (post-v2.0.0 policy: v1.x has no maintenance window)."
     )
 
 


### PR DESCRIPTION
## Summary

The original Phase 7 design (D10 / SI-07-07) committed to a 6-month security-fix window for v1.x ending `2026-12-23`. **Policy revised post-v2.0.0 to a clean break**: v1.x is frozen at v1.3.0 on Docker Hub with no active maintenance.

This PR removes the misleading "security fixes for 6 months" / EOS-date wording from every consumer-facing surface so we don't promise patches we don't ship.

### Changes

- `SECURITY.md`: supported-versions table v1.x row → `**Not maintained.** Frozen at v1.3.0 on Docker Hub. No security fixes are committed to v1.x; please migrate to v2.x.`
- `docs/migration/v1-to-v2.md`: status admonition rewritten.
- `docs/index.md`: `/v1/` description rewritten ("not maintained; users should migrate to v2").
- `docs/admin/repo-settings.md`: §9 v1 frozen-snapshot index.md heredoc + §11 Docker Hub banner template + Notes section all rewritten with "not maintained".
- `docs/adr/0002-v2-clean-break.md`: revised the "Neutral / 6-month security-supported path" consequence to "Bad / not maintained" (policy revision note inline).

### Structural tests

- `test_security_md_has_v1_eos_date` + `test_security_md_mentions_v1_x_six_month_window` → `test_security_md_states_v1_not_maintained`
- `test_migration_guide_has_v1_eos_date` → `test_migration_guide_states_v1_not_maintained`
- `test_runbook_propagates_v1_eos_date` → `test_runbook_propagates_v1_not_maintained_wording`
- Constant renamed `V1_NOT_MAINTAINED_TOKEN` → `V1_NOT_MAINTAINED_WORDING` to avoid ruff S105 false positive.

## Test plan

- [x] `uv run pytest tests/structural -q --no-cov` → 201 passed
- [x] `uv run --extra docs mkdocs build --strict` exits 0
- [ ] CI green on this PR
- [ ] Companion update on PR #59 to drop the v1.x sponsorship-hook line