### PR TITLE
docs(site): exclude docs/admin/ from public docs site + fix v1 banner

### DIFF
--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -438,7 +438,8 @@ gh attestation verify --owner yves-vogl ghcr.io/yves-vogl/aws-eks-helm-deploy:2
 
 The following text is to be pasted verbatim into the Docker Hub repo description
 at https://hub.docker.com/repository/docker/yvogl/aws-eks-helm-deploy (per
-`docs/admin/repo-settings.md` §7 maintainer runbook):
+`docs/admin/repo-settings.md` §11 in the in-repo maintainer runbook —
+intentionally not published on this docs site):
 
 ```
 ⚠ This repository is FROZEN at v1.3.0.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,13 @@ strict: true
 # Phase 7 / Plan 07-04: docs/guides/v1-to-v2.md was `git mv`-ed to
 # docs/migration/v1-to-v2.md in Wave 2. docs/build.md remains excluded — superseded
 # by per-section docs and removed in a later plan.
+# Post-v2.0.0: docs/admin/ is the maintainer-only runbook (gh api commands for
+# branch protection, label taxonomy, Pages enablement, mike one-shots, etc.) —
+# stays in the repo for version control but does NOT belong on the public docs
+# site. Excluded here so mkdocs --strict doesn't include it in nav / search.
 exclude_docs: |
   build.md
+  admin/
 
 theme:
   name: material
@@ -86,5 +91,3 @@ nav:
       - Variables: reference/variables.md
   - ADRs:
       - Overview: adr/index.md
-  - Admin:
-      - Repo Settings Runbook: admin/repo-settings.md

--- a/tests/structural/test_mkdocs_build.py
+++ b/tests/structural/test_mkdocs_build.py
@@ -25,6 +25,10 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 MKDOCS_YML = REPO_ROOT / "mkdocs.yml"
 
+# Note: the "Admin" slot (docs/admin/repo-settings.md) was removed from the
+# published nav post-v2.0.0 — the runbook is for maintainers only and the
+# file is excluded via exclude_docs in mkdocs.yml. It stays in the repo for
+# version control but does not belong on the public docs site.
 REQUIRED_NAV_TITLES: frozenset[str] = frozenset(
     {
         "Home",
@@ -33,7 +37,6 @@ REQUIRED_NAV_TITLES: frozenset[str] = frozenset(
         "Guides",
         "Reference",
         "ADRs",
-        "Admin",
     }
 )
 


### PR DESCRIPTION
## Summary

Two fixes spotted on the live docs site:

1. **`/v2/admin/repo-settings/` is published** — it's a maintainer-only runbook (gh api commands for branch protection, Pages, mike one-shots) and shouldn't be on the public docs site.
2. **`/v1/` still had the "security fixes for 6 months" banner** — even though PR #60 fixed the wording in the repo, the `mike deploy v1` from the v2.0.0 ceremony was never re-run, so the deployed snapshot still carried the old text.

### Changes

- `mkdocs.yml`: add `admin/` to `exclude_docs`, remove the `Admin` nav slot. The file stays in the repo for version control and is still reachable via the GitHub source view (blob/main link from PR template + STATE.md).
- `tests/structural/test_mkdocs_build.py`: drop `Admin` from `REQUIRED_NAV_TITLES`.
- `docs/migration/v1-to-v2.md`: fix the stale `§7` reference to `§11` (post-Phase-6-restore numbering) + note the runbook is intentionally not on the docs site.

### v1 site re-deployed (already live)

Ran `mike deploy --push --config-file .v1-snapshot/mkdocs.yml v1` with the corrected `v1.x is not maintained` banner. `gh-pages` tree now serves the new content; CDN edge cache may take 1-2 minutes.

## Test plan

- [x] `uv run pytest tests/structural -q --no-cov` → 201 passed
- [x] `uv run --extra docs mkdocs build --strict` exits 0 (no `Admin` slot, no warnings)
- [x] `git show origin/gh-pages:v1/index.html | grep 'not maintained'` matches (v1 site already redeployed)
- [ ] CI green on this PR