### PR TITLE
fix(sec): bump helm 3.21.2 + cosign 3.1.1; promote trivy-image to hard gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,13 @@ jobs:
       - name: Install integration dependencies
         run: uv sync --group integration --frozen
 
-      - name: Set up Helm (3.18.x — matches Dockerfile pin)
+      - name: Set up Helm (3.21.x — matches Dockerfile pin)
         # The GitHub-hosted runner's pre-installed helm version is unstable across
-        # runner image refreshes; pin to 3.18.x so tests that use --untar-dir and
-        # other flags introduced/preserved in 3.18 run reliably.
+        # runner image refreshes; pin to 3.21.x so tests that use --untar-dir and
+        # other flags introduced/preserved in 3.18+ run reliably.
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.18.6
+          version: v3.21.2
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
@@ -108,18 +108,6 @@ jobs:
   trivy-image:
     name: "trivy-image"
     runs-on: ubuntu-24.04
-    # TODO(security-review): the 9-entry .trivyignore covers Go stdlib CVEs in
-    # the pinned helm 3.18.6 binary. The current Trivy DB additionally surfaces
-    # ~12 HIGH findings across go-binary internals (containerd, docker/cli,
-    # otel, oauth2, x/crypto, x/net, go-jose) AND CVE-2025-53547 in
-    # helm.sh/helm/v3 itself — the helm CLI surface IS reachable through the
-    # pipe and that CVE needs explicit security-engineer review before being
-    # suppressed. Until that review lands, the gate stays advisory (SARIF still
-    # uploads to Code Scanning, so visibility is preserved). The two-pass
-    # split-scan workaround below (table → gate, sarif → visibility) is the
-    # mechanism fix for the Trivy SARIF+ignorefile interaction reported in the
-    # ship-checklist; the remaining failure is a content-curation TODO.
-    continue-on-error: true
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/cosign-verify.yml
+++ b/.github/workflows/cosign-verify.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: "v2.6.3"
+          cosign-release: "v3.1.1"
 
       - name: Probe :latest existence (bootstrap-graceful)
         id: probe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: "v2.6.3"   # match Dockerfile pin (Phase 4 D8 carry-forward)
+          cosign-release: "v3.1.1"   # match Dockerfile pin (Phase 4 D8 carry-forward)
 
       - name: Compute version tags
         id: tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.7
 ARG PYTHON_VERSION=3.13
 ARG UV_VERSION=0.11.21
-ARG HELM_VERSION=3.18.6
+ARG HELM_VERSION=3.21.2
 ARG HELM_DIFF_VERSION=3.10.0
-ARG COSIGN_VERSION=2.6.3
+ARG COSIGN_VERSION=3.1.1
 
 # Base image digests — pinned for reproducible builds and supply-chain safety.
 # Dependabot's `docker` ecosystem (.github/dependabot.yml) keeps these current

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ The `ghcr.io/yves-vogl/aws-eks-helm-deploy:2` image bundles:
 | Component                      | Version             | Notes                                                                  |
 | ------------------------------ | ------------------- | ---------------------------------------------------------------------- |
 | Base image                     | `python:3.13-slim-bookworm` | Pinned by SHA; non-root user (`USER pipe`, uid ≥ 10000).        |
-| Helm                           | `3.18.6`            | Bundled (no `kubectl` required). See the [Helm version skew policy](https://helm.sh/docs/topics/version_skew/). |
+| Helm                           | `3.21.2`            | Bundled (no `kubectl` required). See the [Helm version skew policy](https://helm.sh/docs/topics/version_skew/). |
 | `helm-diff`                    | `3.10.0`            | Plugin for `ACTION=diff`; SHA-pinned binary.                           |
-| Cosign                         | `2.6.3`             | Bundled for image-side signature operations.                           |
+| Cosign                         | `3.1.1`             | Bundled for image-side signature operations.                           |
 | `kubectl`                      | not bundled         | The pipe generates a kubeconfig and talks to the EKS API directly.     |
 | `boto3`                        | latest stable       | Generates the EKS token natively — no `awscli` in the image.           |
 | `bitbucket-pipes-toolkit`      | `~=6.2`             | Pipe scaffolding, schema validation, logging.                          |

--- a/tests/acceptance/test_image_has_cosign.py
+++ b/tests/acceptance/test_image_has_cosign.py
@@ -1,4 +1,4 @@
-"""Acceptance test: the built runtime image bundles cosign 2.6.3 in /usr/local/bin/.
+"""Acceptance test: the built runtime image bundles cosign 3.1.1 in /usr/local/bin/.
 
 Requirements traceability:
     CHART-04 (Phase 4): cosign must be present in the runtime image to support
@@ -26,7 +26,7 @@ def test_cosign_binary_in_path(built_image: str) -> None:
 
     Asserts:
         - ``which cosign`` exits 0 and returns ``/usr/local/bin/cosign``
-        - ``cosign version`` exits 0 and prints ``GitVersion`` (cosign 2.x version output)
+        - ``cosign version`` exits 0 and prints ``GitVersion`` (cosign 3.x version output)
     """
     result = subprocess.run(
         [

--- a/tests/structural/test_release_yml_sign_attest.py
+++ b/tests/structural/test_release_yml_sign_attest.py
@@ -114,14 +114,15 @@ def test_sign_attest_installs_cosign_at_pinned_sha(release_workflow: dict[str, A
     )
 
 
-def test_sign_attest_installs_cosign_v_2_6_3(release_workflow: dict[str, Any]) -> None:
-    """cosign-installer must pin cosign-release to v2.6.3 — Dockerfile Phase 4 D8 carry-forward."""
+def test_sign_attest_installs_cosign_v_3_1_1(release_workflow: dict[str, Any]) -> None:
+    """cosign-installer must pin cosign-release to v3.1.1 — matches Dockerfile pin."""
     steps = _get_sign_attest_steps(release_workflow)
     step = _step_has_uses(steps, "sigstore/cosign-installer@")
     assert step is not None, "cosign-installer step not found in sign-and-attest job"
     cosign_release: str = step.get("with", {}).get("cosign-release", "")
-    assert cosign_release == "v2.6.3", (
-        f"cosign-installer must pin cosign-release to 'v2.6.3' (Phase 4 D8); got {cosign_release!r}"
+    assert cosign_release == "v3.1.1", (
+        f"cosign-installer must pin cosign-release to 'v3.1.1' "
+        f"(matches Dockerfile); got {cosign_release!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Bumps `HELM_VERSION` `3.18.6 → 3.21.2` and `COSIGN_VERSION` `2.6.3 → 3.1.1` across all pin sites (Dockerfile, CI integration job, release.yml + cosign-verify.yml installers, structural+acceptance tests, README).
- Removes the TODO block + `continue-on-error: true` on the `trivy-image` job in `.github/workflows/ci.yml` — gate becomes hard.
- Closes #67.

## Why

Trivy v0.71.2 surfaced ~12 additional HIGH findings on the v2.0.0 image. PR #66 fixed the Trivy SARIF + ignorefile **mechanism** bug via the split-scan workaround; this PR is the **content-curation** follow-up.

Per `loop-security-engineer` review (2026-06-23) the clean path is **bump, not suppress**:

| Component | Decision | Notes |
|---|---|---|
| `helm.sh/helm/v3` — **CVE-2025-53547** | NO-OP | Fixed in helm 3.18.4; pipe already shipped 3.18.6. Pipe never invokes `helm dependency update`, so the vulnerable `writeLock` symlink path was unreachable regardless. |
| containerd, docker/cli, docker/docker, otel/{sdk,propagation}, x/oauth2, x/crypto, x/net, go-jose/v4 (~12 CVEs) | BUMP | All are transitive Go libs compiled into helm/cosign; vulnerable code paths are not reachable through the pipe's CLI surface (no HTTP listener, OTEL runtime-disabled, Linux-only runtime, no SSH server). The bump picks up upstream fixes for the underlying libs in one shot. |

## Why bump beats more `.trivyignore` entries

Growing the suppression list ages the bundled binaries. A bump moves us forward instead of accumulating exception debt. The cosign `2.x → 3.x` jump is a major version, but verified the pipe's cosign surface uses only v3-stable flags: `verify`, `sign --yes`, `attest --yes --predicate --type`, `--certificate-identity[-regexp]`, `--certificate-oidc-issuer`.

## Carry-overs and follow-ups

- The 9 existing Go-stdlib `.trivyignore` entries (expires 2026-09-18) target helm 3.18.6. After bump they become no-ops against 3.21.2 binaries. Kept in place for now; cleanup tracked as follow-up after CI confirms zero matches.
- Helm v3 maintenance ends **2026-11-11**. Migration to v4 needs to be tracked as a separate follow-up before EOL.

## Test plan

- [x] Structural tests pass locally (201 passed; includes the renamed `test_sign_attest_installs_cosign_v_3_1_1`).
- [x] Pre-commit hooks pass (ruff + ruff format + mypy + secrets scan + unit tests).
- [ ] CI `trivy-image` gate goes green against the new image (proves the bump closes all 12 findings).
- [ ] CI `integration` job passes against the bumped helm 3.21.2 pin.
- [ ] CI `acceptance` job passes (the bundled cosign 3.x still prints `GitVersion` and lives at `/usr/local/bin/cosign`).
- [ ] CI `trivy-dockerfile`, `trivy-secret`, `pip-audit`, `docs-drift`, `lint-typecheck`, `unit-coverage` all green.
- [ ] Manual: `helm diff version` build-stage assertion in Dockerfile (L154) confirms helm-diff 3.10.0 stays compatible with helm 3.21.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbYbh8MVVU822aaAELHqCN