### PR TITLE
chore(ci): set release-please bootstrap-sha to v2.0.0 commit

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,6 +8,7 @@
   "include-v-in-tag": true,
   "draft": false,
   "prerelease": false,
+  "bootstrap-sha": "30e6d090adbcedc507e2dbb6704913950aac482e",
   "extra-files": [
     {
       "type": "yaml",


### PR DESCRIPTION
## Summary

Follow-up to #73. Adds the single missing config field that release-please needs to actually open the v3.0.0 Release PR.

## Diagnosis

After #73 merged, the release-please workflow ran successfully (no more \"Missing required manifest config\" error) but it did not open a Release PR. The log showed:

\`\`\`
✔ Building pull requests
❯ commit search depth: 500
❯ Set(0) {}
❯ Fetching merge commits on branch main with cursor: undefined
❯ Backfilling file list for commit: 7e398b67… (the chore(ci) bootstrap merge)
❯ Found 3 files
✔ Splitting 0 commits by path
\`\`\`

release-please-action's bootstrap behaviour for repos whose previous release (v2.0.0) was cut by hand — not by release-please — is to walk **only the latest commit** since there's no managed-release record to anchor a walk from. The latest commit was the #73 chore(ci) merge, which is a no-version-bump commit, so the action exited without opening a PR.

## Fix

Sets \`bootstrap-sha\` in \`.release-please-config.json\` to the SHA of the v2.0.0 commit:

\`\`\`
30e6d090adbcedc507e2dbb6704913950aac482e
\`\`\`

(\`docs(07): mark Phase 7 deferred-items resolved + carry Phase 6 follow-ups (#49)\` — the commit the v2.0.0 tag points to.)

After this lands, release-please walks all commits since \`30e6d09\`, finds the \`feat(helm)!\` commit with the \`BREAKING CHANGE\` footer, and proposes \`3.0.0\`.

## Follow-up

\`bootstrap-sha\` is only needed for the initial bootstrap. After v3.0.0 ships (release-please-managed), the action gains its own state and can walk from the previous release naturally. Plan to drop the field in a separate cleanup PR after v3.0.0 launches in August.

## Test plan

- [x] Structural tests pass (201 passed; no schema regression).
- [ ] CI green on this PR.
- [ ] After merge: release-please workflow opens the v3.0.0 Release PR.