### PR TITLE
chore(ci): release-as: 3.0.0 one-shot override to unblock v3.0.0 Release PR

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,6 +9,7 @@
   "draft": false,
   "prerelease": false,
   "bootstrap-sha": "30e6d090adbcedc507e2dbb6704913950aac482e",
+  "release-as": "3.0.0",
   "extra-files": [
     {
       "type": "yaml",


### PR DESCRIPTION
## Summary

Follow-up to #73 and #74. PR #74's run log showed why even \`bootstrap-sha\` wasn't enough:

\`\`\`
⚠ Found release tag with component '', but not configured in manifest
✔ Collecting commits since all latest releases
(no PR opened)
\`\`\`

release-please's strategy matcher couldn't reconcile the v2.0.0 GitHub release tag (component=\"\") with the single-path manifest (path=\".\"), so it skipped opening a PR even with bootstrap-sha set.

## Fix

Adds \`\"release-as\": \"3.0.0\"\` to \`.release-please-config.json\`. This bypasses commit-walking entirely and forces release-please to propose \`3.0.0\` as the next release version on the very next workflow run.

## After v3.0.0 ships

Both \`bootstrap-sha\` AND \`release-as\` need to be removed in a single cleanup PR so that release-please's normal commit-walking takes over for v3.0.1+. Tracked under issue #75 (scope updated to cover both fields).

## Test plan

- [x] Pre-commit hooks pass (no source changes — config-only).
- [ ] CI green on this PR.
- [ ] After merge: release-please opens the v3.0.0 Release PR.