### PR TITLE
chore(security): hoist write-token-perms to job level per OpenSSF Scorecard

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,11 +12,10 @@ on:
     # Mondays 07:00 UTC — separate hour from scorecard.yml to avoid collision.
     - cron: '0 7 * * 1'
 
+# Top-level permissions are read-only per OpenSSF Scorecard best practice
+# (least-privilege GITHUB_TOKEN); write scopes are hoisted to job level below.
 permissions:
   contents: read
-  security-events: write
-  # actions: read needed for CodeQL to find workflows when analysing actions.
-  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +26,12 @@ jobs:
     name: analyze (python)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      # security-events:write so CodeQL can upload SARIF to Code Scanning.
+      security-events: write
+      # actions:read so CodeQL can resolve workflow refs when analysing actions.
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,9 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Top-level permissions are read-only per OpenSSF Scorecard best practice
+# (least-privilege GITHUB_TOKEN); write scopes are hoisted to job level below.
 permissions:
-  contents: write          # for gh pr merge
-  pull-requests: write     # for gh pr review --approve + gh pr merge --auto
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -20,6 +21,9 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    permissions:
+      contents: write          # for gh pr merge --squash --auto
+      pull-requests: write     # for gh pr review --approve + gh pr merge --auto
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,12 +10,17 @@ concurrency:
   group: docs-deploy-${{ github.ref }}
   cancel-in-progress: false
 
+# Top-level permissions are read-only per OpenSSF Scorecard best practice
+# (least-privilege GITHUB_TOKEN); the gh-pages push needs contents:write at
+# job level only.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # mike push to gh-pages branch
     steps:
       - name: Checkout (full history needed for mike to push gh-pages)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,11 @@ on:
   push:
     branches: [main]
 
+# Top-level permissions are read-only per OpenSSF Scorecard best practice
+# (least-privilege GITHUB_TOKEN); release-please needs contents:write +
+# pull-requests:write at job level only.
 permissions:
-  contents: write          # release-please pushes the release branch
-  pull-requests: write     # release-please opens/updates the Release PR
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,6 +27,9 @@ jobs:
   release-please:
     name: release-please
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write          # release-please pushes the release branch
+      pull-requests: write     # release-please opens/updates the Release PR
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ on:
         description: "Tag to (re-)release (e.g. v2.0.0)"
         required: true
 
+# Top-level permissions are read-only per OpenSSF Scorecard best practice
+# (least-privilege GITHUB_TOKEN); all write scopes are hoisted to job level on
+# the two jobs that need them (build, sign-and-attest).
 permissions:
-  contents: write          # GitHub Release creation (Plan 06-04 extension)
-  packages: write          # push image + cosign signature artifact to GHCR
-  id-token: write          # OIDC token for Fulcio cert issuance (Plan 06-04)
-  attestations: write      # SLSA provenance (Plan 06-04)
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -41,6 +41,11 @@ jobs:
     name: build (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write    # docker push to GHCR
+      id-token: write    # OIDC token for GHCR push auth
+      attestations: write # SLSA build provenance via actions/attest-build-provenance
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/security-rescan.yml
+++ b/.github/workflows/security-rescan.yml
@@ -9,10 +9,10 @@ on:
     - cron: '17 6 * * *'  # daily ~06:17 UTC (off the :00/:30 mark); 07:17 Berlin winter / 08:17 summer
   workflow_dispatch:
 
+# Top-level permissions are read-only per OpenSSF Scorecard best practice
+# (least-privilege GITHUB_TOKEN); SARIF upload + issue creation hoisted to job.
 permissions:
   contents: read
-  security-events: write  # SARIF upload to Code Scanning
-  issues: write           # auto-issue creation
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +23,10 @@ jobs:
     name: trivy rescan (${{ matrix.tag }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write  # SARIF upload to Code Scanning
+      issues: write           # auto-issue creation on CRITICAL/HIGH findings
     strategy:
       fail-fast: false
       matrix:

--- a/tests/structural/test_docs_yml_structure.py
+++ b/tests/structural/test_docs_yml_structure.py
@@ -37,9 +37,22 @@ def test_docs_yml_concurrency_cancel_in_progress_false() -> None:
     assert "docs-deploy-" in data["concurrency"]["group"]
 
 
-def test_docs_yml_permissions_only_contents_write() -> None:
+def test_docs_yml_permissions_least_privilege() -> None:
+    """Workflow-level perms are read-only; contents:write is hoisted to the deploy job.
+
+    OpenSSF Scorecard best practice (TokenPermissionsID) — least-privilege
+    GITHUB_TOKEN. The mike push to gh-pages still needs contents:write at job
+    level only.
+    """
     data = _load()
-    assert data["permissions"] == {"contents": "write"}
+    assert data["permissions"] == {"contents": "read"}, (
+        f"Top-level permissions must be {{'contents': 'read'}}; got {data['permissions']!r}"
+    )
+    deploy_perms = data["jobs"]["deploy"].get("permissions", {})
+    assert deploy_perms.get("contents") == "write", (
+        f"Job 'deploy' must declare permissions.contents:write for the mike gh-pages push; "
+        f"got {deploy_perms!r}"
+    )
 
 
 def test_docs_yml_uses_40_char_sha_pins() -> None:

--- a/tests/structural/test_release_yml_structure.py
+++ b/tests/structural/test_release_yml_structure.py
@@ -22,7 +22,7 @@ RELEASE_YML_PATH = (
     pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
 )
 
-REQUIRED_WORKFLOW_PERMISSIONS: frozenset[str] = frozenset(
+REQUIRED_JOB_PERMISSIONS: frozenset[str] = frozenset(
     {"contents", "packages", "id-token", "attestations"}
 )
 
@@ -131,16 +131,44 @@ def test_release_workflow_does_not_trigger_on_pull_request(
     )
 
 
-def test_release_workflow_declares_required_permissions(release_workflow: dict[str, Any]) -> None:
-    """Workflow-level permissions must include contents/packages/id-token/attestations: write."""
+def test_release_workflow_top_level_perms_are_read_only(release_workflow: dict[str, Any]) -> None:
+    """Workflow-level perms are read-only; write scopes hoist to per-job blocks.
+
+    OpenSSF Scorecard best practice (TokenPermissionsID) — least-privilege
+    GITHUB_TOKEN. Write scopes (contents/packages/id-token/attestations) are
+    declared on the build + sign-and-attest jobs only.
+    """
     perms: dict[str, Any] = release_workflow.get("permissions", {})
-    missing = REQUIRED_WORKFLOW_PERMISSIONS - set(perms.keys())
-    assert not missing, (
-        f"release.yml workflow-level permissions missing: {missing}. "
-        "Plan 06-04 (sign-and-attest) inherits these from the workflow level."
+    assert perms == {"contents": "read"}, (
+        f"Workflow-level permissions must be {{'contents': 'read'}}; got {perms!r}"
     )
-    for perm in REQUIRED_WORKFLOW_PERMISSIONS:
-        assert perms[perm] == "write", f"Expected permissions.{perm}: write, got {perms[perm]!r}"
+
+
+def test_release_build_and_sign_jobs_declare_required_perms(
+    release_workflow: dict[str, Any],
+) -> None:
+    """Both the build job and the sign-and-attest job must carry the write scopes.
+
+    contents:write, packages:write, id-token:write, attestations:write — required
+    for GHCR push, Fulcio cert issuance, and SLSA provenance attestation.
+    """
+    jobs = release_workflow.get("jobs", {})
+    for job_name in ("build", "sign-and-attest"):
+        job_perms: dict[str, Any] = jobs.get(job_name, {}).get("permissions", {})
+        # contents may be 'read' on build or 'write' on sign-and-attest; the four
+        # write scopes (packages/id-token/attestations) must always be 'write'.
+        write_required = REQUIRED_JOB_PERMISSIONS - {"contents"}
+        for perm in write_required:
+            assert job_perms.get(perm) == "write", (
+                f"Job '{job_name}' permissions.{perm} must be 'write'; "
+                f"got {job_perms.get(perm)!r} (full block: {job_perms!r})"
+            )
+        # contents must be at least 'read'; 'write' (needed on sign-and-attest for
+        # the GitHub Release edit) is also acceptable.
+        assert job_perms.get("contents") in {"read", "write"}, (
+            f"Job '{job_name}' must declare permissions.contents (read or write); "
+            f"got {job_perms.get('contents')!r}"
+        )
 
 
 def test_release_workflow_concurrency_cancel_false(release_workflow: dict[str, Any]) -> None:

--- a/tests/structural/test_security_rescan_yml.py
+++ b/tests/structural/test_security_rescan_yml.py
@@ -144,26 +144,33 @@ def test_security_rescan_no_id_token_write(workflow: dict[str, Any]) -> None:
 
 
 def test_security_rescan_permissions_minimal(workflow: dict[str, Any]) -> None:
-    """Workflow-level permissions must include contents:read, security-events:write, issues:write.
+    """Workflow-level perms are read-only; write scopes hoisted to the rescan job.
 
-    NO id-token present at all (Pitfall #1 guard).
+    OpenSSF Scorecard best practice (TokenPermissionsID) — least-privilege
+    GITHUB_TOKEN. The rescan job still needs security-events:write (SARIF
+    upload) and issues:write (auto-issue creation) at job level only.
+
+    NO id-token present at workflow OR job level (Pitfall #1 guard — checked
+    independently by test_security_rescan_no_id_token_anywhere).
     """
-    perms: Any = workflow.get("permissions", {})
-    assert isinstance(perms, dict), (
-        f"Expected 'permissions:' to be a dict; got {type(perms).__name__}"
+    wf_perms: Any = workflow.get("permissions", {})
+    assert isinstance(wf_perms, dict), (
+        f"Expected workflow-level 'permissions:' to be a dict; got {type(wf_perms).__name__}"
     )
-    assert perms.get("contents") == "read", (
-        f"Expected permissions.contents: read; got {perms.get('contents')!r}"
+    assert wf_perms == {"contents": "read"}, (
+        f"Workflow-level permissions must be {{'contents': 'read'}} only; got {wf_perms!r}"
     )
-    assert perms.get("security-events") == "write", (
-        f"Expected permissions.security-events: write; got {perms.get('security-events')!r}"
+    job_perms: Any = workflow.get("jobs", {}).get("rescan", {}).get("permissions", {})
+    assert job_perms.get("contents") == "read", (
+        f"Job 'rescan' must declare permissions.contents:read; got {job_perms.get('contents')!r}"
     )
-    assert perms.get("issues") == "write", (
-        f"Expected permissions.issues: write; got {perms.get('issues')!r}"
+    assert job_perms.get("security-events") == "write", (
+        f"Job 'rescan' must declare permissions.security-events:write for the SARIF upload; "
+        f"got {job_perms.get('security-events')!r}"
     )
-    assert "id-token" not in perms, (
-        f"Pitfall #1 violation: permissions must NOT include 'id-token' in security-rescan.yml; "
-        f"found permissions.id-token: {perms.get('id-token')!r}"
+    assert job_perms.get("issues") == "write", (
+        f"Job 'rescan' must declare permissions.issues:write for auto-issue creation; "
+        f"got {job_perms.get('issues')!r}"
     )
 
 


### PR DESCRIPTION
Resolves the 7 OpenSSF Scorecard `TokenPermissionsID` Security-tab findings (alerts #1, #233-238) by refactoring six workflows to **workflow-level perms read-only, write scopes hoisted to job level**.

## Changes per workflow

| Workflow | Before (workflow-level) | After (workflow-level → job-level move) |
|---|---|---|
| codeql.yml | contents:read, security-events:write, actions:read | contents:read; analyze job carries the writes |
| dependabot-auto-merge.yml | contents:write, pull-requests:write | contents:read; auto-merge job carries the writes |
| docs.yml | contents:write | contents:read; deploy job carries contents:write for mike push |
| release-please.yml | contents:write, pull-requests:write | contents:read; release-please job carries the writes |
| release.yml | contents/packages/id-token/attestations all :write | contents:read; both build + sign-and-attest jobs carry the four writes (Pitfall #1 invariant preserved — id-token still only in release.yml) |
| security-rescan.yml | contents:read, security-events:write, issues:write | contents:read; rescan job carries the writes (no id-token anywhere — Pitfall #1) |

## Structural test updates (still 100% coverage)

- `test_docs_yml_permissions_only_contents_write` → `test_docs_yml_permissions_least_privilege`
- `test_security_rescan_permissions_minimal` asserts the new layout
- `test_release_workflow_declares_required_permissions` split into `test_release_workflow_top_level_perms_are_read_only` + `test_release_build_and_sign_jobs_declare_required_perms` (build job now covered, +1 net test)

## Verification

- `pytest tests/unit tests/structural -q --no-cov` → **202 passed** (+1 vs main).
- Pre-commit hooks pass.
- Pitfall #1 invariants preserved everywhere.

## Findings remaining after this PR (not actionable here)

- CodeQL jinja2/autoescape-false on pipe/pipe.py — v1.x legacy, frozen.
- Scorecard FuzzingID / CIIBestPracticesID / VulnerabilitiesID / CodeReviewID — out-of-band repo-hygiene heuristics, not source CVEs.
- Scorecard PinnedDependenciesID on Dockerfile (medium) — apt-get install lines aren't digest-pinned; tracked separately if needed.